### PR TITLE
Set raises exception flag to make test easier

### DIFF
--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -3,7 +3,7 @@ from time import sleep
 
 import os
 
-from utilities.utilities import g
+from utilities.utilities import g, set_genie_python_raises_exceptions
 
 
 class TestDae(unittest.TestCase):
@@ -33,8 +33,13 @@ class TestDae(unittest.TestCase):
             spectra=table_path_template.format("spectra"))
         g.change_tcb(0, 10000, 100)
         g.change_finish()
+        set_genie_python_raises_exceptions(False)
+
+    def tearDown(self):
+        set_genie_python_raises_exceptions(False)
 
     def test_GIVEN_run_state_is_running_WHEN_attempt_to_change_simulation_mode_THEN_error(self):
+        set_genie_python_raises_exceptions(True)
         g.begin()
         for _ in range(self.TIMEOUT):
             if g.get_runstate() == "RUNNING":
@@ -43,7 +48,7 @@ class TestDae(unittest.TestCase):
             self.fail("Could not start run")
 
         with self.assertRaises(ValueError):
-            g.API.dae.set_simulation_mode(False)  # Have to use API as user-level command doesn't raise
+            g.set_dae_simulation_mode(False)
 
     def test_GIVEN_run_state_is_setup_WHEN_attempt_to_change_simulation_mode_THEN_simulation_mode_changes(self):
         if g.get_runstate() != "SETUP":

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -8,9 +8,11 @@ from time import sleep
 
 # import genie either from the local project in pycharm or from virtual env
 try:
+    from source import genie_api_setup
     from source import genie as g
 except ImportError:
     from genie_python import genie as g
+    from genie_python import genie_api_setup
 
 # import genie utilities either from the local project in pycharm or from virtual env
 try:
@@ -94,3 +96,15 @@ def get_server_status():
 
     except Exception:
         return None
+
+
+def set_genie_python_raises_exceptions(does_throw):
+    """
+    Set that genie python api raises exceptions instead of just logging a message
+    Args:
+        does_throw: True if it should raise, False otherwise
+
+    Returns:
+
+    """
+    genie_api_setup._exceptions_raised = does_throw


### PR DESCRIPTION
Fix failing build by using genie python straight and setting the throw flag

This failed after API is no longer in genie it is in setup and was being referenced.