### PR TITLE
Add system tests for cset using keywords args

### DIFF
--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -51,12 +51,32 @@ class TestBlockUtils(unittest.TestCase):
             assert_that(g.cget(mbbi_block_name)["value"], is_(expected_val))
 
     @retry_on_failure(3)
+    def test_GIVE_config_with_mbbi_block_WHEN_set_and_get_block_value_using_kwarg_syntax_THEN_value_is_set_and_read(self):
+        mbbi_block_name = "MBBI_BLOCK"
+        assert_that(mbbi_block_name, is_in(g.get_blocks()))
+
+        for expected_val in ["CHEERFUL", "HAPPY"]:
+            g.cset(**{mbbi_block_name: expected_val})
+            g.waitfor_block(mbbi_block_name, value=expected_val, maxwait=TIMEOUT)
+            assert_that(g.cget(mbbi_block_name)["value"], is_(expected_val))
+
+    @retry_on_failure(3)
     def test_GIVE_config_with_bi_block_WHEN_set_and_get_block_value_THEN_value_is_set_and_read(self):
         bi_block_name = "BI_BLOCK"
         assert_that(bi_block_name, is_in(g.get_blocks()))
 
         for expected_val in ["NO", "YES"]:
             g.cset(bi_block_name, expected_val)
+            g.waitfor_block(bi_block_name, value=expected_val, maxwait=TIMEOUT)
+            assert_that(g.cget(bi_block_name)["value"], is_(expected_val))
+
+    @retry_on_failure(3)
+    def test_GIVE_config_with_bi_block_WHEN_set_and_get_block_value_using_kwarg_syntax_THEN_value_is_set_and_read(self):
+        bi_block_name = "BI_BLOCK"
+        assert_that(bi_block_name, is_in(g.get_blocks()))
+
+        for expected_val in ["NO", "YES"]:
+            g.cset(**{bi_block_name: expected_val})
             g.waitfor_block(bi_block_name, value=expected_val, maxwait=TIMEOUT)
             assert_that(g.cget(bi_block_name)["value"], is_(expected_val))
 


### PR DESCRIPTION
### Description of work

Adds system tests to ensure the keyword argument syntax for `g.cset` works properly.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4152

### Acceptance criteria

- [x] Tests in this PR would have caught the bug in the original ticket.

### Unit tests

- See unit tests added in genie_python PR

### System tests

- Yes

### Documentation

Not required for this change.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

