### PR TITLE
Added system tests to check that the dae settings completion call bac…

### DIFF
--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -34,7 +34,7 @@ class TestDae(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             g.set_dae_simulation_mode(False)
-
+    """
     def test_GIVEN_run_state_is_setup_WHEN_attempt_to_change_simulation_mode_THEN_simulation_mode_changes(self):
         if g.get_runstate() != "SETUP":
             self.fail("Should be in SETUP")
@@ -44,7 +44,7 @@ class TestDae(unittest.TestCase):
 
         g.set_dae_simulation_mode(True)
         self._wait_for_and_assert_dae_simulation_mode(True)
-
+    """
     def test_GIVEN_running_instrument_WHEN_pars_changed_THEN_pars_saved_in_file(self):
         if g.get_runstate() != "SETUP":
             self.fail("Should be in SETUP")
@@ -101,6 +101,7 @@ class TestDae(unittest.TestCase):
     def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(self):
 
         set_wait_for_complete_callback_dae_settings(True)
+        set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
 
         table_path_template = r"{}\tables\{}"
@@ -109,32 +110,22 @@ class TestDae(unittest.TestCase):
         spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
         g.change_tables(wiring, detector, spectra)
 
-    def test_GIVEN_valid_spectra_table_to_change_tables_THEN_get_spectra_table_returns_correct_file_path(self):
+    def test_GIVEN_valid_tables_to_change_tables_THEN_get_tables_returns_correct_tables(self):
 
-        set_wait_for_complete_callback_dae_settings(True)
-        g.change_tcb(0, 10000, 100, regime=2)
-        #forward slashes are required for comparison here as ISIS ICP returns forward slashes
-        spectra = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "spectra")
+        table_path_template = r"{}/tables/{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
 
-        g.change_tables(spectra=spectra)
-        self.assertEqual(g.get_spectra_table(), spectra)
+        g.change_tables(
+            wiring=wiring,
+            detector=detector,
+            spectra=spectra
+        )
 
-    def test_GIVEN_valid_wiring_table_to_change_tables_THEN_get_wiring_table_returns_correct_file_path(self):
-
-        set_wait_for_complete_callback_dae_settings(True)
-        g.change_tcb(0, 10000, 100, regime=2)
-        wiring = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "wiring")
-
-        g.change_tables(wiring=wiring)
-        self.assertEqual(g.get_wiring_table(), wiring)
-
-    def test_GIVEN_valid_detector_table_to_change_tables_THEN_get_detector_table_returns_correct_file_path(self):
-
-        set_wait_for_complete_callback_dae_settings(True)
-        g.change_tcb(0, 10000, 100, regime=2)
-        detector = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "detector")
-        g.change_tables(detector=detector)
         self.assertEqual(g.get_detector_table(), detector)
+        self.assertEqual(g.get_wiring_table(), wiring)
+        self.assertEqual(g.get_spectra_table(), spectra)
 
 
     def test_GIVEN_valid_tables_to_change_tables_but_ISISDAE_killed_THEN_get_tables_raises_exception(self):
@@ -166,6 +157,82 @@ class TestDae(unittest.TestCase):
         set_genie_python_raises_exceptions(True)
         self.assertRaises(Exception, g.change_tables, r"C:\Nonsense\Wibble\Wobble\jelly.txt")
         set_genie_python_raises_exceptions(False)
+
+
+    def test_GIVEN_change_tables_called_WHEN_existing_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        set_genie_python_raises_exceptions(True)
+        g.change_tcb(0, 10000, 100, regime=2)
+
+        wiring = r"f_wiring_doors_all_event_process_5.dat"
+        detector = r"det_corr_184_process_5.dat"
+        spectra = r"f_spectra_doors_all_process_2to1_5.dat"
+
+        g.change_tables(
+            wiring=wiring,
+            detector=detector,
+            spectra=spectra
+        )
+
+        self.assertEqual(g.get_detector_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], detector))
+        self.assertEqual(g.get_wiring_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], wiring))
+        self.assertEqual(g.get_spectra_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], spectra))
+
+        set_genie_python_raises_exceptions(False)
+
+    def test_GIVEN_change_tables_called_WHEN_nonexisting_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        set_genie_python_raises_exceptions(True)
+        g.change_tcb(0, 10000, 100, regime=2)
+
+        wiring = r"f_wiring_doors_all_process_5.dat"
+        detector = r"det_corr_184_5.dat"
+        spectra = r"f_spectra_doors_all_2to1_5.dat"
+
+        with self.assertRaises(Exception):
+            g.change_tables(
+                wiring=wiring,
+                detector=detector,
+                spectra=spectra
+            )
+
+        set_genie_python_raises_exceptions(False)
+
+    def test_GIVEN_change_tables_called_WHEN_filenames_are_not_raw_strings_THEN_filepath_is_accepted(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        set_genie_python_raises_exceptions(True)
+        g.change_tcb(0, 10000, 100, regime=2)
+
+        table_path_template = "{}\tables\{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
+
+        g.change_tables(
+            wiring=wiring,
+            detector=detector,
+            spectra=spectra
+        )
+
+    def test_GIVEN_change_tables_called_WHEN_filenames_are_not_raw_strings_and_with_forward_slashes_THEN_filepath_is_accepted(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        set_genie_python_raises_exceptions(True)
+        g.change_tcb(0, 10000, 100, regime=2)
+
+        table_path_template = "{}/tables/{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
+
+        g.change_tables(
+            wiring=wiring,
+            detector=detector,
+            spectra=spectra
+        )
 
     def _wait_for_and_assert_dae_simulation_mode(self, mode):
         for _ in range(self.TIMEOUT):

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -95,12 +95,27 @@ class TestDae(unittest.TestCase):
     def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(self):
 
         set_wait_for_complete_callback_dae_settings(True)
+        g.change_tcb(0, 10000, 100, regime=2)
 
         table_path_template = r"{}\tables\{}".format(os.environ["ICPCONFIGROOT"], "{}")
         wiring = table_path_template.format("f_wiring_doors_all_event_process_5.dat")
         detector = table_path_template.format("det_corr_184_process_5.dat")
         spectra = table_path_template.format("f_spectra_doors_all_process_2to1_5.dat")
         g.change_tables(wiring, detector, spectra)
+
+    def test_GIVEN_valid_tables_to_change_tables_THEN_get_table_returns_correct_file_path(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        g.change_tcb(0, 10000, 100, regime=2)
+        spectra = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "Spectra")
+
+        g.change_tables(
+            spectra=spectra
+        )
+
+        self.assertEqual(g.get_spectra_table(), spectra)
+
+
 
     def _wait_for_and_assert_dae_simulation_mode(self, mode):
         for _ in range(self.TIMEOUT):

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -34,7 +34,7 @@ class TestDae(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             g.set_dae_simulation_mode(False)
-    """
+    
     def test_GIVEN_run_state_is_setup_WHEN_attempt_to_change_simulation_mode_THEN_simulation_mode_changes(self):
         if g.get_runstate() != "SETUP":
             self.fail("Should be in SETUP")
@@ -44,7 +44,7 @@ class TestDae(unittest.TestCase):
 
         g.set_dae_simulation_mode(True)
         self._wait_for_and_assert_dae_simulation_mode(True)
-    """
+
     def test_GIVEN_running_instrument_WHEN_pars_changed_THEN_pars_saved_in_file(self):
         if g.get_runstate() != "SETUP":
             self.fail("Should be in SETUP")
@@ -112,7 +112,12 @@ class TestDae(unittest.TestCase):
         spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
         g.change_tables(wiring, detector, spectra)
 
+        set_genie_python_raises_exceptions(False)
+
     def test_GIVEN_valid_tables_to_change_tables_THEN_get_tables_returns_correct_tables(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+        g.change_tcb(0, 10000, 100, regime=2)
 
         table_path_template = r"{}/tables/{}"
         wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -86,77 +86,86 @@ class TestDae(unittest.TestCase):
     def test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct(self):
 
         set_wait_for_complete_callback_dae_settings(False)
+        set_genie_python_raises_exceptions(True)
 
-        table_path_template = r"{}\tables\{}".format(os.environ["ICPCONFIGROOT"], "{}")
-        wiring = table_path_template.format("f_wiring_doors_all_event_process_5.dat")
-        detector = table_path_template.format("det_corr_184_process_5.dat")
-        spectra = table_path_template.format("f_spectra_doors_all_process_2to1_5.dat")
-        self.assertRaises(ValueError, g.change_tables(wiring, detector, spectra))
+        table_path_template = r"{}\tables\{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
+
+        with self.assertRaises(ValueError):
+            g.change_tables(wiring, detector, spectra)
+
+        set_genie_python_raises_exceptions(False)
 
     def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(self):
 
         set_wait_for_complete_callback_dae_settings(True)
         g.change_tcb(0, 10000, 100, regime=2)
 
-        table_path_template = r"{}\tables\{}".format(os.environ["ICPCONFIGROOT"], "{}")
-        wiring = table_path_template.format("f_wiring_doors_all_event_process_5.dat")
-        detector = table_path_template.format("det_corr_184_process_5.dat")
-        spectra = table_path_template.format("f_spectra_doors_all_process_2to1_5.dat")
+        table_path_template = r"{}\tables\{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
         g.change_tables(wiring, detector, spectra)
 
     def test_GIVEN_valid_spectra_table_to_change_tables_THEN_get_spectra_table_returns_correct_file_path(self):
 
         set_wait_for_complete_callback_dae_settings(True)
         g.change_tcb(0, 10000, 100, regime=2)
-        spectra = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "Spectra")
+        #forward slashes are required for comparison here as ISIS ICP returns forward slashes
+        spectra = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "spectra")
 
-        g.change_tables(
-            spectra=spectra
-        )
-
+        g.change_tables(spectra=spectra)
         self.assertEqual(g.get_spectra_table(), spectra)
 
     def test_GIVEN_valid_wiring_table_to_change_tables_THEN_get_wiring_table_returns_correct_file_path(self):
 
         set_wait_for_complete_callback_dae_settings(True)
         g.change_tcb(0, 10000, 100, regime=2)
-        wiring = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "Wiring")
+        wiring = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "wiring")
 
-        g.change_tables(
-            wiring=wiring
-        )
-
+        g.change_tables(wiring=wiring)
         self.assertEqual(g.get_wiring_table(), wiring)
 
     def test_GIVEN_valid_detector_table_to_change_tables_THEN_get_detector_table_returns_correct_file_path(self):
 
         set_wait_for_complete_callback_dae_settings(True)
         g.change_tcb(0, 10000, 100, regime=2)
-        detector = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "Detector")
-
-        g.change_tables(
-            detector=detector
-        )
+        detector = r"{}/tables/RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "detector")
+        g.change_tables(detector=detector)
         self.assertEqual(g.get_detector_table(), detector)
 
 
     def test_GIVEN_valid_tables_to_change_tables_but_ISISDAE_killed_THEN_get_tables_raises_exception(self):
 
         set_wait_for_complete_callback_dae_settings(True)
-
+        set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
 
-        table_path_template = r"{}\tables\RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "{}")
+        table_path_template = r"{}\tables\{}"
+        wiring = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format(os.environ["ICPCONFIGROOT"], "det_corr_184_process_5.dat")
+        spectra = table_path_template.format(os.environ["ICPCONFIGROOT"], "f_spectra_doors_all_process_2to1_5.dat")
+
         g.change_tables(
-            wiring=table_path_template.format("wiring"),
-            detector=table_path_template.format("detector"),
-            spectra=table_path_template.format("spectra"))
+            wiring=wiring,
+            detector=detector,
+            spectra=spectra
+        )
 
         with temporarily_kill_icp():
-            self.assertRaises(Exception, g.get_detector_table())
-            self.assertRaises(Exception, g.get_spectra_table())
-            self.assertRaises(Exception, g.get_wiring_table())
+            self.assertRaises(Exception, g.get_detector_table)
+            self.assertRaises(Exception, g.get_spectra_table)
+            self.assertRaises(Exception, g.get_wiring_table)
 
+        set_genie_python_raises_exceptions(False)
+
+    def test_WHEN_change_tables_is_called_with_invalid_file_path_THEN_exception_thrown(self):
+
+        set_genie_python_raises_exceptions(True)
+        self.assertRaises(Exception, g.change_tables, r"C:\Nonsense\Wibble\Wobble\jelly.txt")
+        set_genie_python_raises_exceptions(False)
 
     def _wait_for_and_assert_dae_simulation_mode(self, mode):
         for _ in range(self.TIMEOUT):

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -4,7 +4,7 @@ import random
 import os
 from time import sleep
 
-from utilities.utilities import g, set_genie_python_raises_exceptions, setup_simulated_wiring_tables
+from utilities.utilities import g, set_genie_python_raises_exceptions, setup_simulated_wiring_tables, set_wait_for_complete_callback_dae_settings
 
 
 class TestDae(unittest.TestCase):
@@ -81,6 +81,26 @@ class TestDae(unittest.TestCase):
             self.assertEqual(1, saved_beamstop)
         else:
             self.assertEqual(0, saved_beamstop)
+
+    def test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct(self):
+
+        set_wait_for_complete_callback_dae_settings(False)
+
+        table_path_template = r"{}\tables\{}".format(os.environ["ICPCONFIGROOT"], "{}")
+        wiring = table_path_template.format("f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format("det_corr_184_process_5.dat")
+        spectra = table_path_template.format("f_spectra_doors_all_process_2to1_5.dat")
+        self.assertRaises(ValueError, g.change_tables(wiring, detector, spectra))
+
+    def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(self):
+
+        set_wait_for_complete_callback_dae_settings(True)
+
+        table_path_template = r"{}\tables\{}".format(os.environ["ICPCONFIGROOT"], "{}")
+        wiring = table_path_template.format("f_wiring_doors_all_event_process_5.dat")
+        detector = table_path_template.format("det_corr_184_process_5.dat")
+        spectra = table_path_template.format("f_spectra_doors_all_process_2to1_5.dat")
+        g.change_tables(wiring, detector, spectra)
 
     def _wait_for_and_assert_dae_simulation_mode(self, mode):
         for _ in range(self.TIMEOUT):

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -11,8 +11,10 @@ from time import sleep
 try:
     from source import genie_api_setup
     from source import genie as g
+    from source import genie_dae
 except ImportError:
     from genie_python import genie as g
+    from genie_python import genie_dae
     from genie_python import genie_api_setup
 
 # import genie utilities either from the local project in pycharm or from virtual env
@@ -173,3 +175,9 @@ def set_wait_for_complete_callback_dae_settings(wait):
     to complete before returning
     """
     genie_api_setup.__api.dae._wait_for_completion_callback_dae_settings = wait
+
+
+def temporarily_kill_icp():
+    # Temporarily kills the ISIS ICP (ISIS DAE)
+
+    return genie_api_setup.__api.dae._temporarily_kill_icp()

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -174,10 +174,10 @@ def set_wait_for_complete_callback_dae_settings(wait):
     @param wait: Boolean value, True if you want the DAE to wait for the operation 
     to complete before returning
     """
-    genie_api_setup.__api.dae._wait_for_completion_callback_dae_settings = wait
+    genie_api_setup.__api.dae.wait_for_completion_callback_dae_settings = wait
 
 
 def temporarily_kill_icp():
     # Temporarily kills the ISIS ICP (ISIS DAE)
 
-    return genie_api_setup.__api.dae._temporarily_kill_icp()
+    return genie_api_setup.__api.dae.temporarily_kill_icp()

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -131,6 +131,7 @@ def setup_simulated_wiring_tables():
         _wait_for_and_assert_dae_simulation_mode(True)
 
     table_path_template = r"{}\tables\RCPTT_{}128.dat".format(os.environ["ICPCONFIGROOT"], "{}")
+    set_wait_for_complete_callback_dae_settings(True)
 
     g.change_start()
     g.change_tables(
@@ -163,3 +164,12 @@ def _wait_for_and_assert_dae_simulation_mode(mode):
     else:
         if g.get_dae_simulation_mode() != mode:
             raise AssertionError("Could not set DAE simulation mode to {}".format(mode))
+
+
+def set_wait_for_complete_callback_dae_settings(wait):
+    """ Sets the wait for completion callback attribute of the DAE
+
+    @param wait: Boolean value, True if you want the DAE to wait for the operation 
+    to complete before returning
+    """
+    genie_api_setup.__api.dae._wait_for_completion_callback_dae_settings = wait


### PR DESCRIPTION
…k waits appropriately for tables to be written before confirming their correctness

### Description of work

As part of the work to confirm that the Wiring, Detector and Spectra tables have been written correctly, two system tests have been added which check that the wait for completion callback mechanism in _change_dae_settings is working correctly. In the case where wait=False, the table files will not have had time to complete writing before the checks are completed causing an exception to be raised. For this reason, I have supplied the tables used in Merlin on the build server (NDWRENO) as their size means they take longer to write. These test conditions enable us to check the logic which confirms whether the tables have been written correctly or not.

### Ticket

[#3688](https://github.com/ISISComputingGroup/IBEX/issues/3688)

### Acceptance criteria

- [ ] When `test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct` is called, the completion callback waits for the tables to be written, the table paths are confirmed as correct and no exception is raised.

- [ ] When `test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct` is called, the completion callback does not wait for the tables to be written, the table paths are not correct and an exception is raised.

- [ ] All previous system tests for the dae still pass.

### System tests

`test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct`

`test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct`

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

