### PR TITLE
Added system tests for waitfor_pv command

### DIFF
--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -1,9 +1,14 @@
 import functools
+from threading import Thread
 
 from hamcrest import *
+
+import threading
 import unittest
 
+from genie_python.channel_access_exceptions import UnableToConnectToPVException
 from utilities.utilities import load_config_if_not_already_loaded, g
+
 
 TIMEOUT = 30
 SIMPLE_CONFIG_NAME = "rcptt_simple"
@@ -32,6 +37,21 @@ def retry_on_failure(max_times):
                 raise err
         return wrapper
     return decorator
+
+
+def delayed_set_pv(wait_before_set, wait_after_set, pv, value_to_set):
+    """
+    Sets a PV value with a given wait in seconds before and after.
+
+    Params:
+        wait_before_set(int): Number of seconds to wait before setting the PV value
+        wait_after_set(int): Number of seconds to wait after setting the PV value
+        pv(string): The PV to set
+        value_to_set: The value to set on the target PV
+    """
+    g.waitfor_time(seconds=wait_before_set)
+    g.set_pv(pv, value_to_set)
+    g.waitfor_time(seconds=wait_after_set)
 
 
 class TestBlockUtils(unittest.TestCase):
@@ -95,3 +115,44 @@ class TestBlockUtils(unittest.TestCase):
         for expected_val in ["NO", "YES"]:
             g.set_pv(bi_pv_name, expected_val, is_local=True, wait=True)
             assert_that(g.get_pv(bi_pv_name, is_local=True), is_(expected_val))
+
+
+class TestWaitforPV(unittest.TestCase):
+
+    def setUp(self):
+        load_config_if_not_already_loaded(SIMPLE_CONFIG_NAME)
+
+    def test_GIVEN_pv_does_not_exist_WHEN_waiting_for_pv_THEN_error_is_returned(self):
+        pv_name = g.prefix_pv_name("NONSENSE:PV")
+
+        with self.assertRaises(UnableToConnectToPVException):
+            g.adv.wait_for_pv(pv_name, 0, maxwait=10)
+
+    def test_GIVEN_pv_reaches_correct_value_WHEN_waiting_for_pv_THEN_waitfor_returns_before_timeout(self):
+        pv_name = g.prefix_pv_name("SIMPLE:VALUE1:SP")
+        g.set_pv(pv_name, 0)
+        wait_before = 1
+        wait_after = 5
+        max_wait = (wait_before + wait_after) * 2
+        value_to_wait_for = 2
+
+        set_pv_thread = threading.Thread(target=delayed_set_pv, args=(wait_before, wait_after, pv_name, value_to_wait_for))
+        set_pv_thread.start()
+        g.adv.wait_for_pv(pv_name, value_to_wait_for, maxwait=max_wait)
+
+        assert_that(set_pv_thread.is_alive(), is_(True), "Waitfor should have finished because pv has changed")
+
+    def test_GIVEN_pv_change_but_not_to_correct_value_WHEN_waiting_for_pv_THEN_timeout(self):
+        pv_name = g.prefix_pv_name("SIMPLE:VALUE1:SP")
+        g.set_pv(pv_name, 0)
+        value_to_wait_for = 2
+        wrong_value = 3
+        wait_before = 1
+        wait_after = 5
+        max_wait = (wait_before + wait_after) * 2
+
+        set_pv_thread = threading.Thread(target=delayed_set_pv, args=(wait_before, wait_after, pv_name, wrong_value))
+        set_pv_thread.start()
+        g.adv.wait_for_pv(pv_name, value_to_wait_for, maxwait=max_wait)
+
+        assert_that(set_pv_thread.is_alive(), is_(False), "SetPV thread should have finished before maxwait has passed.")

--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -1,5 +1,4 @@
 import functools
-from threading import Thread
 
 from hamcrest import *
 
@@ -120,6 +119,7 @@ class TestBlockUtils(unittest.TestCase):
 class TestWaitforPV(unittest.TestCase):
 
     def setUp(self):
+        g.set_instrument(None)
         load_config_if_not_already_loaded(SIMPLE_CONFIG_NAME)
 
     def test_GIVEN_pv_does_not_exist_WHEN_waiting_for_pv_THEN_error_is_returned(self):


### PR DESCRIPTION
### Description of work

System tests to check `waitfor_pv` command works. Needed for zeroing motors for reflectometry via genie_python.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3895

### Acceptance criteria

- [x] Sensible set of tests
- [x] All tests pass

### Unit tests

-

### System tests

-

### Documentation

-

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

