### PR TITLE
Ticket4992 raise invalid period exception

### DIFF
--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 
 EXTREMELY_LARGE_NO_OF_PERIODS = 1000000
 
-DAE_PERIOD_TIMEOUT = 3
+DAE_PERIOD_TIMEOUT_SECONDS = 15
 
 BLOCK_FORMAT_PATTERN = "@{block_name}@"
 
@@ -371,9 +371,9 @@ class TestDae(unittest.TestCase):
     def _wait_for_dae_period_change(self, expected_value, get_function):
         """
         Checks if the value returned by the given function is th same as the expected values. If not, it tries again
-        after a couple seconds anf repeats the process up to a number of times equal to the DAE_PERIOD_TIMEOUT constant
-        of this module. This method is meant to be used for checking the result of changing the number of period or the
-        period. Therefore, the function is meant to be either g.get_period() or g.get_number_periods. This method is
+        after a couple seconds anf repeats the process up to a number of times equal to the DAE_PERIOD_TIMEOUT_SECONDS
+        constant of this module. This method is meant to be used for checking the result of changing the number of period
+        or the period. Therefore, the function is meant to be either g.get_period() or g.get_number_periods. This method is
         needed since those functions do not return the new values immediately after they are changed, so for the tests
         to pass we need to wait a bit.
 
@@ -381,11 +381,11 @@ class TestDae(unittest.TestCase):
         expected_value (int): the expected value returned by the function
         get_function (() -> int): the function for which we check that it will return a certain value.
         """
-        for _ in range(DAE_PERIOD_TIMEOUT):
+        for _ in range(DAE_PERIOD_TIMEOUT_SECONDS):
             current_value = get_function()
 
             if current_value == expected_value:
                 return expected_value
             else:
-                sleep(5)
+                sleep(1)
         self.fail("dae period or number of periods read timed out")

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -13,6 +13,8 @@ from utilities.utilities import g, genie_dae, set_genie_python_raises_exceptions
 from parameterized import parameterized
 from contextlib import contextmanager
 
+TOO_MANY_PERIODS_FOR_DAE = 1000000
+
 BLOCK_FORMAT_PATTERN = "@{block_name}@"
 
 class TestDae(unittest.TestCase):
@@ -326,7 +328,7 @@ class TestDae(unittest.TestCase):
         sleep(10)
         self.assertEqual(g.get_number_periods(), 30)
 
-        self.assertRaises(IOError, g.change_number_soft_periods, 1000000)
+        self.assertRaises(IOError, g.change_number_soft_periods, TOO_MANY_PERIODS_FOR_DAE)
         self.assertEqual(g.get_number_periods(), 30)
 
         set_genie_python_raises_exceptions(False)
@@ -362,6 +364,6 @@ class TestDae(unittest.TestCase):
             try:
                 g.get_sample_pars()
                 return
-            except:
+            except Exception:
                 sleep(1)
-        self.assertEqual(0, 1)
+        self.fail("sample pars did not return")

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -13,7 +13,7 @@ from utilities.utilities import g, genie_dae, set_genie_python_raises_exceptions
 from parameterized import parameterized
 from contextlib import contextmanager
 
-TOO_MANY_PERIODS_FOR_DAE = 1000000
+EXTREMELY_LARGE_NO_OF_PERIODS = 1000000
 
 BLOCK_FORMAT_PATTERN = "@{block_name}@"
 
@@ -65,13 +65,13 @@ class TestDae(unittest.TestCase):
 
         set_genie_python_raises_exceptions(True)
         g.begin()
-        title = "title{}".format(random.randint(1,1000))
-        geometry = "geometry{}".format(random.randint(1,1000))
-        width = float(random.randint(1,1000))
-        height = float(random.randint(1,1000))
-        l1 = float(random.randint(1,1000))
+        title = "title{}".format(random.randint(1, 1000))
+        geometry = "geometry{}".format(random.randint(1, 1000))
+        width = float(random.randint(1, 1000))
+        height = float(random.randint(1, 1000))
+        l1 = float(random.randint(1, 1000))
         beamstop = random.choice(['OUT','IN'])
-        filename = "c:/windows/temp/test{}.nxs".format(random.randint(1,1000))
+        filename = "c:/windows/temp/test{}.nxs".format(random.randint(1, 1000))
         self._wait_for_sample_pars()
         g.change_title(title)
         g.change_sample_par("width", width)
@@ -328,7 +328,7 @@ class TestDae(unittest.TestCase):
         sleep(10)
         self.assertEqual(g.get_number_periods(), 30)
 
-        self.assertRaises(IOError, g.change_number_soft_periods, TOO_MANY_PERIODS_FOR_DAE)
+        self.assertRaises(IOError, g.change_number_soft_periods, EXTREMELY_LARGE_NO_OF_PERIODS)
         self.assertEqual(g.get_number_periods(), 30)
 
         set_genie_python_raises_exceptions(False)

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -310,6 +310,11 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
+    def test_GIVEN_change_number_soft_periods_called_WHEN_new_value_too_big_for_DAE_hardware_THEN_raise_exception_to_console(self):
+        set_genie_python_raises_exceptions(True)
+        self.assertRaises(IOError, g.change_number_soft_periods, 1000000)
+        set_genie_python_raises_exceptions(False)
+
     def _wait_for_sample_pars(self):
         for _ in range(self.TIMEOUT):
             try:

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -8,7 +8,7 @@ from time import sleep
 
 from utilities.utilities import g, genie_dae, set_genie_python_raises_exceptions, setup_simulated_wiring_tables, \
     set_wait_for_complete_callback_dae_settings, temporarily_kill_icp, \
-    load_config_if_not_already_loaded, _wait_for_and_assert_dae_simulation_mode
+    load_config_if_not_already_loaded, _wait_for_and_assert_dae_simulation_mode, parameterized_list
 
 from parameterized import parameterized
 from contextlib import contextmanager
@@ -310,9 +310,51 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
+    def test_GIVEN_change_number_soft_periods_called_WHEN_new_value_normal_THEN_change_successful(self):
+        set_genie_python_raises_exceptions(True)
+
+        g.change_number_soft_periods(30)
+        sleep(10)
+        self.assertEqual(g.get_number_periods(), 30)
+
+        set_genie_python_raises_exceptions(False)
+
     def test_GIVEN_change_number_soft_periods_called_WHEN_new_value_too_big_for_DAE_hardware_THEN_raise_exception_to_console(self):
         set_genie_python_raises_exceptions(True)
+
+        g.change_number_soft_periods(30)
+        sleep(10)
+        self.assertEqual(g.get_number_periods(), 30)
+
         self.assertRaises(IOError, g.change_number_soft_periods, 1000000)
+        self.assertEqual(g.get_number_periods(), 30)
+
+        set_genie_python_raises_exceptions(False)
+
+    @parameterized.expand(parameterized_list([1, 2, 6, 9, 10]))
+    def test_GIVEN_change_period_called_WHEN_valid_argument_THEN_change_successful(self, _, new_period):
+        set_genie_python_raises_exceptions(True)
+        g.change_number_soft_periods(10)
+        sleep(10)
+        self.assertEqual(g.get_number_periods(), 10)
+
+        g.change_period(new_period)
+        self.assertEqual(g.get_period(), new_period)
+
+        set_genie_python_raises_exceptions(False)
+
+    @parameterized.expand(parameterized_list([-1, 0, 11, 12]))
+    def test_GIVEN_change_period_called_WHEN_invalid_argument_THEN_raise_exception_to_console(self, _, new_period):
+        set_genie_python_raises_exceptions(True)
+        g.change_number_soft_periods(10)
+        sleep(10)
+        self.assertEqual(g.get_number_periods(), 10)
+        g.change_period(1)
+        self.assertEqual(g.get_period(), 1)
+
+        self.assertRaises(IOError, g.change_period, new_period)
+        self.assertEqual(g.get_period(), 1)
+
         set_genie_python_raises_exceptions(False)
 
     def _wait_for_sample_pars(self):

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -35,6 +35,33 @@ when it changed config"""
 DAE_MODE_TIMEOUT = 120
 
 
+def parameterized_list(cases):
+    """
+    Creates a list of cases for parameterized to use to run tests.
+
+    E.g.
+    parameterized_list([1.3435, 12321, 1.0])
+        = [("1.3435", 1.3435),("12321", 12321), ("1.0", 1.0)]
+
+    Args:
+         cases: List of cases to use in tests.
+
+    Returns:
+        list: list of tuples of where the first item is str(case).
+    """
+
+    return_list = []
+
+    for case in cases:
+        test_case = (str(case),)
+        try:
+            return_list.append(test_case + case)
+        except TypeError:
+            return_list.append(test_case + (case,))
+
+    return return_list
+
+
 def load_config_if_not_already_loaded(config_name):
     """
     Load a config be name if it has not already been loaded.


### PR DESCRIPTION
### Description of work

Added system tests to test the genie python commands for changing the period and the total number of periods for both normal and for invalid input. 

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4992

### Acceptance criteria

Newly added system tests pass on dev machines and also on our build server.

### System tests

2 for each of the two methods, one for normal input and for when genie python now throws an error. The tests for change_period are parameterized and use Boundary Value Analysis.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

