### PR TITLE
Ticket5109 run individual tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,148 @@ If you want to run these tests on a developer machine, some files will need to b
     1. rcptt_simple
     
 Once these files are in place, run the tests with `run_tests.bat`
+
+
+
+### Running all tests
+
+
+
+
+
+To run all the tests in the test framework, `cd` to wherever you have the system_tests repository checked out and use:
+
+
+```
+
+
+run_tests.bat
+
+
+```
+
+
+
+
+
+### Running tests in modules
+
+
+
+
+
+You can run tests in specific modules using the `-t` argument as follows:
+
+
+
+
+
+```
+
+
+run_tests.bat -t example_module  # Will run the stress rig tests and then the tests in the module example_module.
+
+
+```
+
+
+
+
+
+The argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` 
+
+
+directory, with the `.py` extension removed.
+
+
+
+
+
+### Running tests in classes
+
+
+
+
+
+You can run classes of tests in modules using the `-t` argument as follows:
+
+
+
+
+
+```
+
+
+run_tests.bat -t module.RunCommandTests # This will run all the tests in the RunCommandTests class in the module module. 
+
+
+```
+
+
+
+
+
+The argument is the "dotted name" of the class containing the tests. The dotted name takes the form `module.class`.
+
+
+
+
+
+### Running tests by name
+
+
+
+
+
+You can run tests by name using `-t` argument as follows:
+
+
+
+
+
+```
+
+
+run_tests.bat -t module.RunCommandTests.test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped # This will run the test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped test in the RunCommandTests class in the module module. 
+
+
+```
+
+
+
+
+
+The argument is the "dotted name" of the test containing the tests. The dotted name takes the form `module.class.test`.
+
+
+You can run multiple tests from multiple classes in different modules.
+
+
+
+
+
+### Running multiple individual tests, or from multiple models or classes
+
+
+
+
+
+You can run multiple individual tests using the `-t` argument as follows:
+
+
+
+
+
+```
+
+
+run_tests.bat -t example_module.ExampleClass.test_if_num_is_correct example_module2.AnotherExampleClass.test_if_bool_is_true
+
+
+```
+
+
+
+
+
+That will test the `test_if_num_is_correct` and `test_if_bool_is_true` from their respective classes. You can also run all tests from multiple specific modules or classes that you want. 

--- a/README.md
+++ b/README.md
@@ -23,146 +23,56 @@ If you want to run these tests on a developer machine, some files will need to b
 Once these files are in place, run the tests with `run_tests.bat`
 
 
-
 ### Running all tests
-
-
-
-
 
 To run all the tests in the test framework, `cd` to wherever you have the system_tests repository checked out and use:
 
-
 ```
-
-
 run_tests.bat
-
-
 ```
-
-
-
 
 
 ### Running tests in modules
 
-
-
-
-
 You can run tests in specific modules using the `-t` argument as follows:
 
-
-
-
-
 ```
-
-
 run_tests.bat -t example_module  # Will run the stress rig tests and then the tests in the module example_module.
-
-
 ```
 
-
-
-
-
-The argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` 
-
-
-directory, with the `.py` extension removed.
-
-
-
+The argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` directory, with the `.py` extension removed.
 
 
 ### Running tests in classes
 
-
-
-
-
 You can run classes of tests in modules using the `-t` argument as follows:
 
-
-
-
-
 ```
-
-
 run_tests.bat -t module.RunCommandTests # This will run all the tests in the RunCommandTests class in the module module. 
-
-
 ```
-
-
-
-
 
 The argument is the "dotted name" of the class containing the tests. The dotted name takes the form `module.class`.
 
 
-
-
-
 ### Running tests by name
-
-
-
-
 
 You can run tests by name using `-t` argument as follows:
 
-
-
-
-
 ```
-
-
 run_tests.bat -t module.RunCommandTests.test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped # This will run the test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped test in the RunCommandTests class in the module module. 
-
-
 ```
-
-
-
-
 
 The argument is the "dotted name" of the test containing the tests. The dotted name takes the form `module.class.test`.
-
 
 You can run multiple tests from multiple classes in different modules.
 
 
-
-
-
 ### Running multiple individual tests, or from multiple models or classes
-
-
-
-
 
 You can run multiple individual tests using the `-t` argument as follows:
 
-
-
-
-
 ```
-
-
 run_tests.bat -t example_module.ExampleClass.test_if_num_is_correct example_module2.AnotherExampleClass.test_if_bool_is_true
-
-
 ```
-
-
-
-
 
 That will test the `test_if_num_is_correct` and `test_if_bool_is_true` from their respective classes. You can also run all tests from multiple specific modules or classes that you want. 

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -2,6 +2,6 @@ setlocal
 call C:\Instrument\Apps\EPICS\config_env.bat
 start /wait cmd /c C:\Instrument\Apps\EPICS\start_ibex_server.bat
 set "PYTHONUNBUFFERED=1"
-%PYTHON% "%~dp0run_tests.py" || echo "running tests failed."
+%PYTHON% "%~dp0run_tests.py" %* || echo "running tests failed."
 call C:\Instrument\Apps\EPICS\ISIS\JournalParser\master\test\run_tests.bat || echo "running tests failed."
 start /wait cmd /c C:\Instrument\Apps\EPICS\stop_ibex_server.bat

--- a/run_tests.py
+++ b/run_tests.py
@@ -41,12 +41,21 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--output_dir', default=DEFAULT_DIRECTORY,
                         help='The directory to save the test reports')
-    args = parser.parse_args()
-    xml_dir = args.output_dir
+    parser.add_argument('-t', '--test', default=None, nargs='+',
+                        help="""Dotted names of tests to run. These are of the form module.class.method.
+                                    Module just runs the tests in a module. 
+                                    Module.class runs the the test class in Module.
+                                    Module.class.method runs a specific test.""")
+
+    arguments = parser.parse_args()
+    xml_dir = arguments.output_dir
 
     # Load tests from test suites
-    test_suite = unittest.TestLoader().discover(SCRIPT_DIRECTORY, pattern="test_*.py")
-
+    if arguments.test is not None:
+        test_suite = unittest.TestLoader().loadTestsFromNames(arguments.test)
+    else:
+        test_suite = unittest.TestLoader().discover(SCRIPT_DIRECTORY, pattern="test_*.py")
+    
     config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
                    if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--output_dir', default=DEFAULT_DIRECTORY,
                         help='The directory to save the test reports')
-    parser.add_argument('-t', '--test', default=None, nargs='+',
+    parser.add_argument('-t', '--tests', default=None, nargs='+',
                         help="""Dotted names of tests to run. These are of the form module.class.method.
                                     Module just runs the tests in a module. 
                                     Module.class runs the the test class in Module.
@@ -51,11 +51,11 @@ if __name__ == '__main__':
     xml_dir = arguments.output_dir
 
     # Load tests from test suites
-    if arguments.test is not None:
-        test_suite = unittest.TestLoader().loadTestsFromNames(arguments.test)
+    if arguments.tests is not None:
+        test_suite = unittest.TestLoader().loadTestsFromNames(arguments.tests)
     else:
         test_suite = unittest.TestLoader().discover(SCRIPT_DIRECTORY, pattern="test_*.py")
-    
+
     config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
                    if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
 


### PR DESCRIPTION
### Description of work

Added code so that you ca give command line arguments with the -t tag to the run_tests.py script so you can run test from individual modules, classes or even individual tests, or multiple individual tests that you name.

Now, you can run a subset of all tests just as you are able to do in the IOC Tests Framework.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5109

### Acceptance criteria

Developers can select indvidual system tests to run

### Documentation
https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Running-Automated-System-Tests

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

