### PR TITLE
made asserts case insensitive

### DIFF
--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -211,9 +211,9 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
-        self.assertEqual(g.get_detector_table(), detector)
-        self.assertEqual(g.get_wiring_table(), wiring)
-        self.assertEqual(g.get_spectra_table(), spectra)
+        self.assertEqual(g.get_detector_table().lower(), detector.lower())
+        self.assertEqual(g.get_wiring_table().lower(), wiring.lower())
+        self.assertEqual(g.get_spectra_table().lower(), spectra.lower())
 
     def test_GIVEN_valid_tables_to_change_tables_but_ISISDAE_killed_THEN_get_tables_raises_exception(self):
         set_wait_for_complete_callback_dae_settings(True)
@@ -259,9 +259,9 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
-        self.assertEqual(g.get_detector_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], detector))
-        self.assertEqual(g.get_wiring_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], wiring))
-        self.assertEqual(g.get_spectra_table(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], spectra))
+        self.assertEqual(g.get_detector_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], detector).lower())
+        self.assertEqual(g.get_wiring_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], wiring).lower())
+        self.assertEqual(g.get_spectra_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], spectra).lower())
 
         set_genie_python_raises_exceptions(False)
 


### PR DESCRIPTION
### Description of work

Two tests were failing since two paths were not equal because one directory was capitalized in one string, but not in the other. Windows paths are case insensitive, so it is irrelevant if it is capitalised or not.

The two system tests were consistently failing on builds before and including #987 .

### Acceptance criteria

The two system tests pass on dev machines and also on Jenkins after this is merged

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

