### PR TITLE
Memory Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ relPaths.sh
 /.idea
 .project
 /test-reports
+base_line_memory.txt

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,5 +1,7 @@
 setlocal
 call C:\Instrument\Apps\EPICS\config_env.bat
+%PYTHON% -c "exec(\"from psutil import virtual_memory\nprint(virtual_memory().used)\")">base_line_memory.txt
+set /P BASE_MEMORY_USAGE=<base_line_memory.txt
 start /wait cmd /c C:\Instrument\Apps\EPICS\start_ibex_server.bat
 set "PYTHONUNBUFFERED=1"
 %PYTHON% "%~dp0run_tests.py" %* || echo "running tests failed."

--- a/test_memory_usage.py
+++ b/test_memory_usage.py
@@ -33,9 +33,7 @@ class TestMemoryUsage(unittest.TestCase):
         """
         mem_info = virtual_memory()
 
-        total_bytes_used = float(mem_info.used) - float(BASE_MEMORY_USAGE)
-
-        mem_usage = total_bytes_used / (2**30)
+        mem_usage = float(mem_info.used) / (2 ** 30)
 
         print("Memory at start, after, diff: {}, {} {} GB".format(BASE_MEMORY_USAGE, mem_info.used, mem_usage))
 

--- a/test_memory_usage.py
+++ b/test_memory_usage.py
@@ -1,5 +1,6 @@
 from hamcrest import *
 import unittest
+import os
 
 from utilities.utilities import load_config_if_not_already_loaded, g, setup_simulated_wiring_tables
 from psutil import virtual_memory
@@ -7,8 +8,11 @@ from psutil import virtual_memory
 TIMEOUT = 30
 TYPICAL_CONFIG_NAME = "memory_usage"
 
+# Contains the memory used by the machine before IBEX was started
+BASE_MEMORY_USAGE = os.environ.get("BASE_MEMORY_USAGE", "0")
 
-class TestBlockUtils(unittest.TestCase):
+
+class TestMemoryUsage(unittest.TestCase):
 
     def setUp(self):
         g.set_instrument(None)
@@ -27,12 +31,13 @@ class TestBlockUtils(unittest.TestCase):
             mem_usage: Float, system memory used in gibibytes (2^30 bytes)
 
         """
-
         mem_info = virtual_memory()
 
-        total_bytes_used = float(mem_info.used)
+        total_bytes_used = float(mem_info.used) - float(BASE_MEMORY_USAGE)
 
         mem_usage = total_bytes_used / (2**30)
+
+        print("Memory at start, after, diff: {}, {} {} GB".format(BASE_MEMORY_USAGE, mem_info.used, mem_usage))
 
         return mem_usage
 


### PR DESCRIPTION
### Description of work

Compares the memory usage difference from before IBEX began and after, rather than the whole usage of the system. This was causing issues on the build server where another process was using a large amount of memory.

### Ticket

* Run something on your machine that is not IBEX part of the IBEX server but uses >9 GB of memory
* Run `run_tests.bat -t test_memory_usage` on master, confirm it fails
* Run `run_tests.bat -t test_memory_usage` on this branch and confirm it passes

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

