### PR TITLE
Actually check memory and assume os usage

### DIFF
--- a/test_memory_usage.py
+++ b/test_memory_usage.py
@@ -11,6 +11,9 @@ TYPICAL_CONFIG_NAME = "memory_usage"
 # Contains the memory used by the machine before IBEX was started
 BASE_MEMORY_USAGE = os.environ.get("BASE_MEMORY_USAGE", "0")
 
+# The assumed memory usage from the rest of the system e.g. os
+ASSUMED_NON_IBEX_USAGE = 2.0
+
 
 class TestMemoryUsage(unittest.TestCase):
 
@@ -33,24 +36,26 @@ class TestMemoryUsage(unittest.TestCase):
         """
         mem_info = virtual_memory()
 
-        mem_usage = float(mem_info.used) / (2 ** 30)
+        total_bytes_used = float(mem_info.used) - float(BASE_MEMORY_USAGE)
+
+        mem_usage = total_bytes_used / (2**30)
 
         print("Memory at start, after, diff: {}, {} {} GB".format(BASE_MEMORY_USAGE, mem_info.used, mem_usage))
 
         return mem_usage
 
     def test_GIVEN_typical_config_with_IOCs_blocks_and_LVDCOM_IOC_WHEN_dae_is_doing_a_run_THEN_memory_usage_stays_under_9point5gb(self):
-        threshold = 9.5
+        system_threshold = 9.5
 
         g.begin()
 
         memory_used = self.get_current_memory_usage()
 
-        assert_that(memory_used, less_than(threshold))
+        assert_that(memory_used, less_than(system_threshold-ASSUMED_NON_IBEX_USAGE))
 
     def test_GIVEN_typical_config_with_IOCs_blocks_and_LVDCOM_IOC_WHEN_dae_is_not_doing_a_run_THEN_memory_usage_stays_under_7point5gb(self):
-        threshold = 7.5
+        system_threshold = 7.5
 
         memory_used = self.get_current_memory_usage()
 
-        assert_that(memory_used, less_than(threshold))
+        assert_that(memory_used, less_than(system_threshold-ASSUMED_NON_IBEX_USAGE))

--- a/test_memory_usage.py
+++ b/test_memory_usage.py
@@ -9,7 +9,7 @@ TIMEOUT = 30
 TYPICAL_CONFIG_NAME = "memory_usage"
 
 # Contains the memory used by the machine before IBEX was started
-BASE_MEMORY_USAGE = os.environ.get("BASE_MEMORY_USAGE", "0")
+BASE_MEMORY_USAGE_IN_BYTES = os.environ.get("BASE_MEMORY_USAGE", "0")
 
 # The assumed memory usage from the rest of the system e.g. os
 ASSUMED_NON_IBEX_USAGE = 2.0
@@ -31,18 +31,22 @@ class TestMemoryUsage(unittest.TestCase):
         Obtains the current system memory usage and returns it in gibibytes
 
         Returns:
-            mem_usage: Float, system memory used in gibibytes (2^30 bytes)
+            mem_usage_difference_gigabytes: Float, system memory used in gibibytes (2^30 bytes)
 
         """
         mem_info = virtual_memory()
 
-        total_bytes_used = float(mem_info.used) - float(BASE_MEMORY_USAGE)
+        total_bytes_used_difference = float(mem_info.used) - float(BASE_MEMORY_USAGE_IN_BYTES)
 
-        mem_usage = total_bytes_used / (2**30)
+        mem_usage_difference_gigabytes = total_bytes_used_difference / (2 ** 30)
 
-        print("Memory at start, after, diff: {}, {} {} GB".format(BASE_MEMORY_USAGE, mem_info.used, mem_usage))
+        base_memory_usage_gigabytes = float(BASE_MEMORY_USAGE_IN_BYTES) / (2 ** 30)
+        total_memory_usage_gigabytes = float(mem_info.used) / (2 ** 30)
 
-        return mem_usage
+        print("Memory at start, after, diff: {}, {}, {} GB".format(base_memory_usage_gigabytes,
+                                                                  total_memory_usage_gigabytes, mem_usage_difference_gigabytes))
+
+        return mem_usage_difference_gigabytes
 
     def test_GIVEN_typical_config_with_IOCs_blocks_and_LVDCOM_IOC_WHEN_dae_is_doing_a_run_THEN_memory_usage_stays_under_9point5gb(self):
         system_threshold = 9.5


### PR DESCRIPTION
### Description of work

Checks memory usage better so that tests can be run on any hardware.

Note: Once this is done we should reinstate these tests on NDHSPARE70

### Ticket

Run the memory system tests on a developer machine with some other large processes running in the background and confirm that they still work.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

