### PR TITLE
Fix deletion retries

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -31,6 +31,8 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 DEFAULT_DIRECTORY = os.path.join(SCRIPT_DIRECTORY, 'test-reports')
 CONFIGS_DIRECTORY = os.path.join(SCRIPT_DIRECTORY, 'configs')
 
+NUM_RETRY_DELETION = 5
+
 # default icp config path
 default_configs_path = os.path.join("C:\\", "Instrument", "Settings", "config",
                                     os.environ.get("COMPUTERNAME", "NAME"), "configurations")
@@ -70,14 +72,14 @@ if __name__ == '__main__':
         for file_or_dir in os.listdir(src):
             file_or_dir_dest = os.path.join(dest, file_or_dir)
             file_or_dir_src = os.path.join(src, file_or_dir)
-            for _ in range(2):
+            for _ in range(NUM_RETRY_DELETION):
                 try:
                     if os.path.isdir(file_or_dir_src):
                         shutil.rmtree(file_or_dir_dest, True)
                     else:
                         os.remove(file_or_dir_dest)
-                except OSError:
-                    pass
+                except OSError as e:
+                    print("Error deleting file {} exception message is {}".format(file_or_dir_dest, e))
                 time.sleep(2)
             if os.path.isdir(file_or_dir_src):
                 shutil.copytree(file_or_dir_src, file_or_dir_dest)

--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -363,8 +363,8 @@ class TestAlerts(unittest.TestCase):
         assert_that(vals['mobiles'], is_(["123456", "789"]))
         assert_that(vals['lowlimit'], is_(10.0))
         assert_that(vals['highlimit'], is_(20.0))
-        assert_that(vals['delay_in'], is_(2.0))
-        assert_that(vals['delay_out'], is_(2.0))
+        assert_that(vals['delay_in'], is_(0.0))
+        assert_that(vals['delay_out'], is_(0.0))
         assert_that(vals['enabled'], is_('NO'))
 
     def test_GIVEN_details_WHEN_message_specified_THEN_alert_message_sent(self):

--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -363,8 +363,8 @@ class TestAlerts(unittest.TestCase):
         assert_that(vals['mobiles'], is_(["123456", "789"]))
         assert_that(vals['lowlimit'], is_(10.0))
         assert_that(vals['highlimit'], is_(20.0))
-        assert_that(vals['delay_in'], is_(0.0))
-        assert_that(vals['delay_out'], is_(0.0))
+        assert_that(vals['delay_in'], is_(2.0))
+        assert_that(vals['delay_out'], is_(2.0))
         assert_that(vals['enabled'], is_('NO'))
 
     def test_GIVEN_details_WHEN_message_specified_THEN_alert_message_sent(self):


### PR DESCRIPTION
### Description of work

Made the error message for when files can not be deleted by the run tests python script be printed. That is to see why the Windows 10 system tests failed.

I changed the assertions for  a test to fix the failure on the normal system test, because as a result of  https://github.com/ISISComputingGroup/EPICS-RunControl/pull/10 the delays have been changed to 0, but the assertions were not.

### Acceptance criteria

the system tests pass succesfully


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

