### PR TITLE
Ticket5861: Retrying in recsim if IOC fails to start

### DIFF
--- a/test_start_stop_ioc_through_proc_control.py
+++ b/test_start_stop_ioc_through_proc_control.py
@@ -156,7 +156,7 @@ class TestProcControl(unittest.TestCase):
     def _retry_in_recsim(errored_iocs: List[str], ioc: str):
         # open with w flag and overwrite - we don't need to
         with open(GLOBALS_FILENAME, "w") as globals_file:
-            globals_file.write(f"{ioc}__SIM=1")
+            globals_file.write(f"{ioc}__RECSIM=1")
             try:
                 start_ioc(ioc_name=ioc)
                 stop_ioc(ioc_name=ioc)

--- a/test_start_stop_ioc_through_proc_control.py
+++ b/test_start_stop_ioc_through_proc_control.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import List
 
 from hamcrest import *
 
@@ -37,6 +38,8 @@ IOCS_TO_IGNORE_START_STOP = [
     'PIXELMAN',
     'CHOPPERSIM',  # Simulation ioc
 ]
+
+GLOBALS_FILENAME = os.path.join(os.environ['ICPCONFIGROOT'], "globals.txt")
 
 
 class TestProcControl(unittest.TestCase):
@@ -126,7 +129,7 @@ class TestProcControl(unittest.TestCase):
 
         iocs = []
         for schema in schemas:
-            iocs.extend([ioc_config.attrib["name"] for ioc_config in root.iter("{}ioc_config".format(schema))])
+            iocs.extend([ioc_config.attrib["name"] for ioc_config in root.iter(f"{schema}ioc_config")])
 
         # Check parsed IOCs are a sensible length
         self.assertGreater(len(iocs), 100)
@@ -137,13 +140,28 @@ class TestProcControl(unittest.TestCase):
 
         for ioc in iocs:
             if any(iocname in ioc for iocname in IOCS_TO_IGNORE_START_STOP):
-                print("skipping {}".format(ioc))
+                print(f"skipping {ioc}")
                 continue
-            print("testing {}".format(ioc))
+            print(f"testing {ioc}")
             # Start/stop ioc also waits for the ioc to start/stop respectively or errors after a 30 second timeout
             try:
                 start_ioc(ioc_name=ioc)
                 stop_ioc(ioc_name=ioc)
             except IOError:
-                errored_iocs.append(ioc)
+                self._retry_in_recsim(errored_iocs, ioc)
+
         self.assertEqual(errored_iocs, [], "IOCs failed: {}".format(errored_iocs))
+
+    @staticmethod
+    def _retry_in_recsim(errored_iocs: List[str], ioc: str):
+        # open with w flag and overwrite - we don't need to
+        with open(GLOBALS_FILENAME, "w") as globals_file:
+            globals_file.write(f"{ioc}__SIM=1")
+            try:
+                start_ioc(ioc_name=ioc)
+                stop_ioc(ioc_name=ioc)
+                pass
+            except IOError:
+                errored_iocs.append(ioc)
+            finally:
+                globals_file.truncate(0)

--- a/test_start_stop_ioc_through_proc_control.py
+++ b/test_start_stop_ioc_through_proc_control.py
@@ -157,10 +157,10 @@ class TestProcControl(unittest.TestCase):
         # open with w flag and overwrite - we don't need to
         with open(GLOBALS_FILENAME, "w") as globals_file:
             globals_file.write(f"{ioc}__RECSIM=1")
+            globals_file.flush()
             try:
                 start_ioc(ioc_name=ioc)
                 stop_ioc(ioc_name=ioc)
-                pass
             except IOError:
                 errored_iocs.append(ioc)
             finally:

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -326,7 +326,7 @@ def is_ioc_up(ioc_name):
     Returns: True if IOC is up; False otherwise
     """
     try:
-        heartbeat = g.get_pv("AS:{}:SR_heartbeat".format(ioc_name), is_local=True)
+        heartbeat = g.get_pv("CS:IOC:{}:DEVIOS:HEARTBEAT".format(ioc_name), is_local=True)
     except UnableToConnectToPVException:
         return False
     return heartbeat is not None


### PR DESCRIPTION
### Description of work

Restarts IOCs in RECSIM if they fail to start in DEVSIM. If they still fail to start, they are reported. 

### Ticket

ISISComputingGroup/IBEX#5861

### Acceptance criteria

See ticket

### Unit tests

N/a

### System tests

Tests now restart an ioc in recsim if they fall over the first time. 


### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

