### PR TITLE
Ticket6519 add system tests for get time since start

### DIFF
--- a/run_tests.bat
+++ b/run_tests.bat
@@ -12,13 +12,12 @@ IF %errorlevel% NEQ 0 (
     echo "running base tests failed."
 	goto finish
 )
-
-@REM call %EPICS_ROOT%\ISIS\JournalParser\master\test\run_tests.bat
-@REM IF %errorlevel% NEQ 0 (
-@REM 	set exitcode=%errorlevel%
-@REM     echo "running journal tests failed."
-@REM 	goto finish
-@REM )
+call %EPICS_ROOT%\ISIS\JournalParser\master\test\run_tests.bat
+IF %errorlevel% NEQ 0 (
+    set exitcode=%errorlevel%
+    echo "running journal tests failed."
+    goto finish
+)
 
 :finish
 python test_setup_teardown.py --tear_down

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -13,12 +13,12 @@ IF %errorlevel% NEQ 0 (
 	goto finish
 )
 
-call %EPICS_ROOT%\ISIS\JournalParser\master\test\run_tests.bat
-IF %errorlevel% NEQ 0 (
-	set exitcode=%errorlevel%
-    echo "running journal tests failed."
-	goto finish
-)
+@REM call %EPICS_ROOT%\ISIS\JournalParser\master\test\run_tests.bat
+@REM IF %errorlevel% NEQ 0 (
+@REM 	set exitcode=%errorlevel%
+@REM     echo "running journal tests failed."
+@REM 	goto finish
+@REM )
 
 :finish
 python test_setup_teardown.py --tear_down

--- a/run_tests.py
+++ b/run_tests.py
@@ -62,29 +62,29 @@ if __name__ == '__main__':
     else:
         test_suite = unittest.TestLoader().discover(SCRIPT_DIRECTORY, pattern="test_*.py")
 
-    # config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
-    #                if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
-    #
-    # for config_dir in config_dirs:
-    #     dest = os.path.join(PATH_TO_ICPCONFIGROOT, config_dir)
-    #     src = os.path.join(CONFIGS_DIRECTORY, config_dir)
-    #
-    #     for file_or_dir in os.listdir(src):
-    #         file_or_dir_dest = os.path.join(dest, file_or_dir)
-    #         file_or_dir_src = os.path.join(src, file_or_dir)
-    #         for _ in range(NUM_RETRY_DELETION):
-    #             try:
-    #                 if os.path.isdir(file_or_dir_src):
-    #                     shutil.rmtree(file_or_dir_dest, True)
-    #                 else:
-    #                     os.remove(file_or_dir_dest)
-    #             except OSError as e:
-    #                 print("Error deleting file {} exception message is {}".format(file_or_dir_dest, e))
-    #             time.sleep(2)
-    #         if os.path.isdir(file_or_dir_src):
-    #             shutil.copytree(file_or_dir_src, file_or_dir_dest)
-    #         else:
-    #             shutil.copy(file_or_dir_src, dest)
+    config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
+                   if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
+
+    for config_dir in config_dirs:
+        dest = os.path.join(PATH_TO_ICPCONFIGROOT, config_dir)
+        src = os.path.join(CONFIGS_DIRECTORY, config_dir)
+
+        for file_or_dir in os.listdir(src):
+            file_or_dir_dest = os.path.join(dest, file_or_dir)
+            file_or_dir_src = os.path.join(src, file_or_dir)
+            for _ in range(NUM_RETRY_DELETION):
+                try:
+                    if os.path.isdir(file_or_dir_src):
+                        shutil.rmtree(file_or_dir_dest, True)
+                    else:
+                        os.remove(file_or_dir_dest)
+                except OSError as e:
+                    print("Error deleting file {} exception message is {}".format(file_or_dir_dest, e))
+                time.sleep(2)
+            if os.path.isdir(file_or_dir_src):
+                shutil.copytree(file_or_dir_src, file_or_dir_dest)
+            else:
+                shutil.copy(file_or_dir_src, dest)
 
     print("\n\n------ BEGINNING genie_python SYSTEM TESTS ------")
     ret_vals = list()

--- a/run_tests.py
+++ b/run_tests.py
@@ -62,29 +62,29 @@ if __name__ == '__main__':
     else:
         test_suite = unittest.TestLoader().discover(SCRIPT_DIRECTORY, pattern="test_*.py")
 
-    config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
-                   if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
-
-    for config_dir in config_dirs:
-        dest = os.path.join(PATH_TO_ICPCONFIGROOT, config_dir)
-        src = os.path.join(CONFIGS_DIRECTORY, config_dir)
-
-        for file_or_dir in os.listdir(src):
-            file_or_dir_dest = os.path.join(dest, file_or_dir)
-            file_or_dir_src = os.path.join(src, file_or_dir)
-            for _ in range(NUM_RETRY_DELETION):
-                try:
-                    if os.path.isdir(file_or_dir_src):
-                        shutil.rmtree(file_or_dir_dest, True)
-                    else:
-                        os.remove(file_or_dir_dest)
-                except OSError as e:
-                    print("Error deleting file {} exception message is {}".format(file_or_dir_dest, e))
-                time.sleep(2)
-            if os.path.isdir(file_or_dir_src):
-                shutil.copytree(file_or_dir_src, file_or_dir_dest)
-            else:
-                shutil.copy(file_or_dir_src, dest)
+    # config_dirs = [name for name in os.listdir(CONFIGS_DIRECTORY)
+    #                if os.path.isdir(os.path.join(CONFIGS_DIRECTORY, name))]
+    #
+    # for config_dir in config_dirs:
+    #     dest = os.path.join(PATH_TO_ICPCONFIGROOT, config_dir)
+    #     src = os.path.join(CONFIGS_DIRECTORY, config_dir)
+    #
+    #     for file_or_dir in os.listdir(src):
+    #         file_or_dir_dest = os.path.join(dest, file_or_dir)
+    #         file_or_dir_src = os.path.join(src, file_or_dir)
+    #         for _ in range(NUM_RETRY_DELETION):
+    #             try:
+    #                 if os.path.isdir(file_or_dir_src):
+    #                     shutil.rmtree(file_or_dir_dest, True)
+    #                 else:
+    #                     os.remove(file_or_dir_dest)
+    #             except OSError as e:
+    #                 print("Error deleting file {} exception message is {}".format(file_or_dir_dest, e))
+    #             time.sleep(2)
+    #         if os.path.isdir(file_or_dir_src):
+    #             shutil.copytree(file_or_dir_src, file_or_dir_dest)
+    #         else:
+    #             shutil.copy(file_or_dir_src, dest)
 
     print("\n\n------ BEGINNING genie_python SYSTEM TESTS ------")
     ret_vals = list()

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+from datetime import datetime
 
 import h5py
 import random
@@ -597,7 +598,10 @@ class TestDae(unittest.TestCase):
 
 
     def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_without_pause_THEN_seconds_returned_is_correct(self):
-
+        """
+        Checks if the seconds elapsed since the start is the same as the expected elapsed seconds.
+        :return:
+        """
         # Arrange
         expected = 5
         g.begin()
@@ -611,23 +615,54 @@ class TestDae(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_seconds_returned_is_correct(self):
-
+        """
+        Checks if the seconds elapsed since the start, including paused time period, is the same as the expected elapsed second with the pause.
+        :return:
+        """
         # Arrange
         sleep_time = 5
         expected = sleep_time*3
+
         g.begin()
         sleep(sleep_time)
         g.pause()
         sleep(sleep_time)
         g.resume()
         sleep(sleep_time)
+        g.end()
 
         # Act
-
         actual = g.get_time_since_start()
 
         # Assert
         self.assertEqual(expected, actual)
+
+    def test_GIVEN_time_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_datetime_returned_is_correct(self):
+        """
+        Checks if the time elapsed since the start is the same as the expected elapsed time. Time is returned in optional choice, as a datetime object.
+        :return:
+        """
+        # Arrange
+        sleep_time = 5
+
+        # Adding time it took since start to the current datetime
+        expected = (sleep_time*3) + datetime.utcnow()
+
+        g.begin()
+        sleep(sleep_time)
+        g.pause()
+        sleep(sleep_time)
+        g.resume()
+        sleep(sleep_time)
+        g.end()
+
+        # Act
+        actual = g.get_time_since_start(True)
+        #Assert
+        self.assertEqual(expected,actual)
+
+
+
 
 
 

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -474,7 +474,7 @@ class TestDae(unittest.TestCase):
         config_line = "{} = {}\r\n".format(begindelay_property, delay_seconds)
         if g.get_runstate() != "SETUP":
             g.abort() # make sure not left in a funny state from e.g. previous aborted test
-        with g._genie_api.dae.temporarily_kill_icp():
+        with temporarily_kill_icp():
             config_found = False
 
             for filepath in icp_properties_files:
@@ -594,3 +594,43 @@ class TestDae(unittest.TestCase):
             else:
                 sleep(1)
         self.fail("dae period or number of periods read timed out")
+
+
+    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_without_pause_THEN_seconds_returned_is_correct(self):
+
+        # Arrange
+        expected = 5
+        g.begin()
+        sleep(expected)
+
+        # Act
+
+        actual = g.get_time_since_start()
+
+        # Assert
+        self.assertEqual(expected, actual)
+
+    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_seconds_returned_is_correct(self):
+
+        # Arrange
+        sleep_time = 5
+        expected = sleep_time*3
+        g.begin()
+        sleep(sleep_time)
+        g.pause()
+        sleep(sleep_time)
+        g.resume()
+        sleep(sleep_time)
+
+        # Act
+
+        actual = g.get_time_since_start()
+
+        # Assert
+        self.assertEqual(expected, actual)
+
+
+
+
+
+

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -600,6 +600,7 @@ class TestDae(unittest.TestCase):
         Checks if the seconds elapsed since the start is the same as the expected elapsed seconds.
         """
         sleep_time = 5
+        tolerance = 1
 
         def get_time_thread(return_value):
             """
@@ -620,8 +621,8 @@ class TestDae(unittest.TestCase):
         thread.join()
 
         # Taking the fluctuation of actual runtime into account and tolerating up to 1 sec difference
-        self.assertAlmostEqual(sleep_time, time_taken[0], delta=1)  # if this fails, then will print the two values
-        self.assertTrue(abs(timedelta(seconds=sleep_time) - time_taken[1]) < timedelta(seconds=1))
+        self.assertAlmostEqual(sleep_time, time_taken[0], delta=tolerance)  # if this fails, then will print the two values
+        self.assertTrue(abs(timedelta(seconds=sleep_time) - time_taken[1]) < timedelta(seconds=tolerance))
 
     def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_seconds_returned_is_correct(self):
         """
@@ -629,6 +630,7 @@ class TestDae(unittest.TestCase):
         is the same as the expected elapsed seconds.
         """
         sleep_time = 5
+        tolerance = 2
 
         # Multiplying sleep time with 3 as it sleeps 3 times between pausing and resuming
         total_sleep_time = sleep_time * 3
@@ -650,5 +652,5 @@ class TestDae(unittest.TestCase):
         expected = total_sleep_time + begin_runtime
 
         # Taking the fluctuation of actual runtime into account and tolerating up to 1 sec difference
-        self.assertAlmostEqual(expected, actual_s, delta=1)  # if this fails, then will print the two values
-        self.assertTrue(abs(timedelta(seconds=expected) - actual_timedelta) < timedelta(seconds=1))
+        self.assertAlmostEqual(expected, actual_s, delta=tolerance)  # if this fails, then will print the two values
+        self.assertTrue(abs(timedelta(seconds=expected) - actual_timedelta) < timedelta(seconds=tolerance))

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -1,7 +1,6 @@
 import time
 import unittest
 from datetime import datetime, timedelta
-
 import h5py
 import random
 import os
@@ -10,9 +9,7 @@ from time import sleep
 
 from utilities.utilities import g, stop_ioc, start_ioc, wait_for_ioc_start_stop, \
     set_genie_python_raises_exceptions, setup_simulated_wiring_tables, \
-    set_wait_for_complete_callback_dae_settings, temporarily_kill_icp, \
-    load_config_if_not_already_loaded, _wait_for_and_assert_dae_simulation_mode, \
-    parameterized_list, get_execution_time
+    set_wait_for_complete_callback_dae_settings, temporarily_kill_icp, load_config_if_not_already_loaded, _wait_for_and_assert_dae_simulation_mode, parameterized_list, get_execution_time
 
 from parameterized import parameterized
 from contextlib import contextmanager
@@ -196,8 +193,7 @@ class TestDae(unittest.TestCase):
             alarm_time = alarm_time[first_alarm_index:final_alarm_index]
 
             self.assertTrue(len(is_valid) == len(test_values) + 1, "Not enough values/value_valid items logged to file")
-            self.assertTrue(len(alarm_severity) == len(test_values) + 1,
-                            "Not enough alarm status/severity items logged to file")
+            self.assertTrue(len(alarm_severity) == len(test_values) + 1,"Not enough alarm status/severity items logged to file")
 
             self.assertListEqual(is_valid, [True, True, True, False])
             # [0] is the value logged by ISISICP when SIMPLE IOC is restarted above
@@ -277,8 +273,7 @@ class TestDae(unittest.TestCase):
             g.cset("LONG_BLOCK", long_test_val, wait=True)
             sleep(10)
 
-    def test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct(
-            self):
+    def test_GIVEN_wait_for_complete_callback_dae_settings_is_false_and_valid_tables_given_THEN_dae_does_not_wait_and_xml_values_are_not_initially_correct(self):
         set_wait_for_complete_callback_dae_settings(False)
         set_genie_python_raises_exceptions(True)
 
@@ -292,8 +287,7 @@ class TestDae(unittest.TestCase):
 
         set_genie_python_raises_exceptions(False)
 
-    def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(
-            self):
+    def test_GIVEN_wait_for_complete_callback_dae_settings_is_true_and_valid_tables_given_THEN_dae_waits_and_xml_values_are_confirmed_correct(self):
         set_wait_for_complete_callback_dae_settings(True)
         set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
@@ -353,8 +347,7 @@ class TestDae(unittest.TestCase):
         self.assertRaises(Exception, g.change_tables, r"C:\Nonsense\Wibble\Wobble\jelly.txt")
         set_genie_python_raises_exceptions(False)
 
-    def test_GIVEN_change_tables_called_WHEN_existing_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(
-            self):
+    def test_GIVEN_change_tables_called_WHEN_existing_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(self):
         set_wait_for_complete_callback_dae_settings(True)
         set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
@@ -369,17 +362,13 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
-        self.assertEqual(g.get_detector_table().lower(),
-                         r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], detector).lower())
-        self.assertEqual(g.get_wiring_table().lower(),
-                         r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], wiring).lower())
-        self.assertEqual(g.get_spectra_table().lower(),
-                         r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], spectra).lower())
+        self.assertEqual(g.get_detector_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], detector).lower())
+        self.assertEqual(g.get_wiring_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], wiring).lower())
+        self.assertEqual(g.get_spectra_table().lower(), r"{}/tables/{}".format(os.environ["ICPCONFIGROOT"], spectra).lower())
 
         set_genie_python_raises_exceptions(False)
 
-    def test_GIVEN_change_tables_called_WHEN_nonexisting_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(
-            self):
+    def test_GIVEN_change_tables_called_WHEN_nonexisting_filenames_provided_not_absolute_paths_THEN_files_found_and_tables_set(self):
         set_wait_for_complete_callback_dae_settings(True)
         set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
@@ -413,8 +402,7 @@ class TestDae(unittest.TestCase):
             spectra=spectra
         )
 
-    def test_GIVEN_change_tables_called_WHEN_filenames_are_not_raw_strings_and_with_forward_slashes_THEN_filepath_is_accepted(
-            self):
+    def test_GIVEN_change_tables_called_WHEN_filenames_are_not_raw_strings_and_with_forward_slashes_THEN_filepath_is_accepted(self):
         set_wait_for_complete_callback_dae_settings(True)
         set_genie_python_raises_exceptions(True)
         g.change_tcb(0, 10000, 100, regime=2)
@@ -438,8 +426,7 @@ class TestDae(unittest.TestCase):
 
         set_genie_python_raises_exceptions(False)
 
-    def test_GIVEN_change_number_soft_periods_called_WHEN_new_value_too_big_for_DAE_hardware_THEN_raise_exception_to_console(
-            self):
+    def test_GIVEN_change_number_soft_periods_called_WHEN_new_value_too_big_for_DAE_hardware_THEN_raise_exception_to_console(self):
         set_genie_python_raises_exceptions(True)
 
         g.change_number_soft_periods(30)
@@ -486,7 +473,8 @@ class TestDae(unittest.TestCase):
         config_line = "{} = {}\r\n".format(begindelay_property, delay_seconds)
         if g.get_runstate() != "SETUP":
             g.abort()  # make sure not left in a funny state from e.g. previous aborted test
-        with temporarily_kill_icp():
+
+        with g._genie_api.dae.temporarily_kill_icp():
             config_found = False
 
             for filepath in icp_properties_files:
@@ -512,8 +500,7 @@ class TestDae(unittest.TestCase):
         time.sleep(15)
         g.waitfor_runstate("SETUP")
 
-    def test_GIVEN_begin_in_progress_WHEN_runcontrol_changes_quickly_in_and_out_of_range_THEN_correct_state_is_eventually_used(
-            self):
+    def test_GIVEN_begin_in_progress_WHEN_runcontrol_changes_quickly_in_and_out_of_range_THEN_correct_state_is_eventually_used(self):
 
         load_config_if_not_already_loaded("rcptt_simple")
 
@@ -608,8 +595,7 @@ class TestDae(unittest.TestCase):
                 sleep(1)
         self.fail("dae period or number of periods read timed out")
 
-    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_without_pause_THEN_time_returned_is_correct(
-            self):
+    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_without_pause_THEN_time_returned_is_correct(self):
         """
         Checks if the seconds elapsed since the start is the same as the expected elapsed seconds.
         """
@@ -637,8 +623,7 @@ class TestDae(unittest.TestCase):
         self.assertAlmostEqual(sleep_time, time_taken[0], delta=1)  # if this fails, then will print the two values
         self.assertTrue(abs(timedelta(seconds=sleep_time) - time_taken[1]) < timedelta(seconds=1))
 
-    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_seconds_returned_is_correct(
-            self):
+    def test_GIVEN_x_seconds_have_elapsed_since_start_WHEN_getting_time_since_start_with_pause_THEN_seconds_returned_is_correct(self):
         """
         Checks if the seconds elapsed since the start, including pause time period,
         is the same as the expected elapsed seconds.

--- a/test_genie_python_dae.py
+++ b/test_genie_python_dae.py
@@ -1,4 +1,5 @@
 import time
+import timeit
 import unittest
 from datetime import datetime
 
@@ -57,7 +58,7 @@ class TestDae(unittest.TestCase):
 
     def setUp(self):
         g.set_instrument(None)
-        self._adjust_icp_begin_delay(0)
+        #self._adjust_icp_begin_delay(0)
 
         # all tests that interact with anything but genie should try to load a config to ensure that the configurations
         # in the tests are not broken, e.g. by a schema update
@@ -645,6 +646,7 @@ class TestDae(unittest.TestCase):
         # Arrange
         sleep_time = 5
 
+        execution_time = timeit.timeit(g.begin)
         # Adding time it took since start to the current datetime
         expected = (sleep_time*3) + datetime.utcnow()
 
@@ -657,9 +659,9 @@ class TestDae(unittest.TestCase):
         g.end()
 
         # Act
-        actual = g.get_time_since_start(True)
+        actual = g.get_time_since_start(True) + execution_time
         #Assert
-        self.assertEqual(expected,actual)
+        self.assertEqual(expected, actual)
 
 
 

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -226,8 +226,7 @@ def _wait_for_and_assert_dae_simulation_mode(mode):
         sleep(1.0)
     if g.get_dae_simulation_mode() != mode:
         sim_val = g.get_pv("DAE:SIM_MODE", is_local=True)
-        raise AssertionError(
-            "Could not set DAE simulation mode to {} - current SIM_MODE PV value is {}".format(mode, sim_val))
+        raise AssertionError("Could not set DAE simulation mode to {} - current SIM_MODE PV value is {}".format(mode, sim_val))
 
 
 def set_wait_for_complete_callback_dae_settings(wait):
@@ -238,12 +237,10 @@ def set_wait_for_complete_callback_dae_settings(wait):
     """
     genie_api_setup.__api.dae.wait_for_completion_callback_dae_settings = wait
 
-
 def temporarily_kill_icp():
     # Temporarily kills the ISIS ICP (ISIS DAE)
 
     return genie_api_setup.__api.dae.temporarily_kill_icp()
-
 
 def as_seconds(time):
     """
@@ -261,7 +258,6 @@ def as_seconds(time):
         seconds += int(bit)
 
     return seconds
-
 
 def _start_stop_ioc_is_a_start(is_a_start, ioc_name):
     """


### PR DESCRIPTION
### Description of work

Added tests forget_time_since_start function in genie_dae.py. 
Created method to get execution time of a method.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6519

### Acceptance criteria

There are system_tests for this function

### System tests

Tests for testing get_time_since start:
    1. With/without pause
    2. Returning seconds(False)/datetime object(True)


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

