### PR TITLE
HOTFIX - Fix Genie Python System Test

### DIFF
--- a/test_genie_python_common_imports.py
+++ b/test_genie_python_common_imports.py
@@ -8,7 +8,8 @@ import importlib
 IGNORED_MODULES = {
     "curses",  # Not supported on windows
     "dockerpty",  # Not supported on windows
-    "adodbapi"  # Not needed by users
+    "adodbapi",  # Not needed by users
+    "black"  # Not needed by users
 }
 
 


### PR DESCRIPTION
Add black library to IGNORED_MODULES variable in test_genie_python_common_imports.py to fix system tests. black is not a required module, but is shipped with ipython library

### Description of work

HOTFIX to Add black to `IGNORED_MODULES` varaible in `system_tests\test_genie_python_common_imports.py` as the dependency is not required, but shipped alongside [Ipython](https://pypi.org/project/ipython/) to pass system tests for release 10.0.0

**see [Jenkins build](https://epics-jenkins.isis.rl.ac.uk/job/System_Tests_release/10/testReport/junit/test_genie_python_common_imports/TestGeniePythonImports/test_WHEN_importing_all_installed_packages_THEN_no_error/) for error being fixed by this PR**

### Acceptance criteria
- [ ] `system_tests\test_genie_python_common_imports.py` system tests now pass

### System tests

- `system_tests\test_genie_python_common_imports.py`
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

