### PR TITLE
Add test for blockserver not restarting IOCS that haven't changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ relPaths.sh
 .project
 /test-reports
 base_line_memory.txt
+/my_venv/

--- a/configs/components/component_with_simple_macros/blocks.xml
+++ b/configs/components/component_with_simple_macros/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_macros/components.xml
+++ b/configs/components/component_with_simple_macros/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_macros/groups.xml
+++ b/configs/components/component_with_simple_macros/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_macros/iocs.xml
+++ b/configs/components/component_with_simple_macros/iocs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="true" restart="true" remotePvPrefix="" simlevel="none">
+		<macros>
+			<macro name="MACRO1" value="1" description="1" pattern=".*$" hasDefault="no"/>
+			<macro name="MACRO2" value="2" description="1" pattern=".*$" hasDefault="no"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/components/component_with_simple_macros/meta.xml
+++ b/configs/components/component_with_simple_macros/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>a</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-07-11 14:12:07</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/components/component_with_simple_no_macros/blocks.xml
+++ b/configs/components/component_with_simple_no_macros/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_no_macros/components.xml
+++ b/configs/components/component_with_simple_no_macros/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_no_macros/groups.xml
+++ b/configs/components/component_with_simple_no_macros/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/components/component_with_simple_no_macros/iocs.xml
+++ b/configs/components/component_with_simple_no_macros/iocs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="true" restart="true" remotePvPrefix="" simlevel="none">
+		<macros/>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/components/component_with_simple_no_macros/meta.xml
+++ b/configs/components/component_with_simple_no_macros/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>a</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-07-11 14:12:17</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/block_in_title/iocs.xml
+++ b/configs/configurations/block_in_title/iocs.xml
@@ -1,5 +1,5 @@
 <iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<ioc autostart="true" name="SIMPLE" remotePvPrefix="" restart="false" simlevel="none">
+	<ioc autostart="true" name="SIMPLE" remotePvPrefix="" restart="true" simlevel="none">
 		<macros />
 		<pvs />
 		<pvsets />

--- a/configs/configurations/simple1/blocks.xml
+++ b/configs/configurations/simple1/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple1/components.xml
+++ b/configs/configurations/simple1/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple1/groups.xml
+++ b/configs/configurations/simple1/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple1/iocs.xml
+++ b/configs/configurations/simple1/iocs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="true" restart="true" remotePvPrefix="" simlevel="none">
+		<macros/>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+	<ioc name="AG33220A_01" autostart="true" restart="true" remotePvPrefix="" simlevel="recsim">
+		<macros>
+			<macro name="IP_ADDRESS" value="" description="IP address of AG33220A" pattern="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" hasDefault="no"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/configurations/simple1/meta.xml
+++ b/configs/configurations/simple1/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>config with nicos 1</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-06-14 15:16:16</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple2/blocks.xml
+++ b/configs/configurations/simple2/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple2/components.xml
+++ b/configs/configurations/simple2/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple2/groups.xml
+++ b/configs/configurations/simple2/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple2/iocs.xml
+++ b/configs/configurations/simple2/iocs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="true" restart="true" remotePvPrefix="" simlevel="none">
+		<macros/>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+	<ioc name="AG3631A_01" autostart="true" restart="true" remotePvPrefix="" simlevel="recsim">
+		<macros>
+			<macro name="PORT" value="" description="Serial COM Port" pattern="^COM[0-9]+$" hasDefault="no"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/configurations/simple2/meta.xml
+++ b/configs/configurations/simple2/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>config with nicos 2</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-06-14 15:16:42</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple_comp_macros/blocks.xml
+++ b/configs/configurations/simple_comp_macros/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros/components.xml
+++ b/configs/configurations/simple_comp_macros/components.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<component name="component_with_simple_macros"/>
+</components>

--- a/configs/configurations/simple_comp_macros/groups.xml
+++ b/configs/configurations/simple_comp_macros/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros/iocs.xml
+++ b/configs/configurations/simple_comp_macros/iocs.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros/meta.xml
+++ b/configs/configurations/simple_comp_macros/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>a</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-07-11 14:12:39</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple_comp_macros_2/blocks.xml
+++ b/configs/configurations/simple_comp_macros_2/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros_2/components.xml
+++ b/configs/configurations/simple_comp_macros_2/components.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<component name="component_with_simple_macros"/>
+</components>

--- a/configs/configurations/simple_comp_macros_2/groups.xml
+++ b/configs/configurations/simple_comp_macros_2/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros_2/iocs.xml
+++ b/configs/configurations/simple_comp_macros_2/iocs.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_macros_2/meta.xml
+++ b/configs/configurations/simple_comp_macros_2/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>a</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-07-11 14:12:39</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple_comp_no_macros/blocks.xml
+++ b/configs/configurations/simple_comp_no_macros/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_no_macros/components.xml
+++ b/configs/configurations/simple_comp_no_macros/components.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<component name="component_with_simple_no_macros"/>
+</components>

--- a/configs/configurations/simple_comp_no_macros/groups.xml
+++ b/configs/configurations/simple_comp_no_macros/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_no_macros/iocs.xml
+++ b/configs/configurations/simple_comp_no_macros/iocs.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_comp_no_macros/meta.xml
+++ b/configs/configurations/simple_comp_no_macros/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>a</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-07-11 14:13:19</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple_with_macros/blocks.xml
+++ b/configs/configurations/simple_with_macros/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_with_macros/components.xml
+++ b/configs/configurations/simple_with_macros/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_with_macros/groups.xml
+++ b/configs/configurations/simple_with_macros/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_with_macros/iocs.xml
+++ b/configs/configurations/simple_with_macros/iocs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="true" restart="true" remotePvPrefix="" simlevel="none">
+		<macros>
+			<macro name="MACRO1" value="1" description="1" pattern=".*$" hasDefault="no"/>
+			<macro name="MACRO2" value="2" description="1" pattern=".*$" hasDefault="no"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/configurations/simple_with_macros/meta.xml
+++ b/configs/configurations/simple_with_macros/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>config with nicos 2</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-06-14 15:16:42</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/configs/configurations/simple_without_autostart/blocks.xml
+++ b/configs/configurations/simple_without_autostart/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_without_autostart/components.xml
+++ b/configs/configurations/simple_without_autostart/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_without_autostart/groups.xml
+++ b/configs/configurations/simple_without_autostart/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/simple_without_autostart/iocs.xml
+++ b/configs/configurations/simple_without_autostart/iocs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="SIMPLE" autostart="false" restart="false" remotePvPrefix="" simlevel="none">
+		<macros/>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/configurations/simple_without_autostart/meta.xml
+++ b/configs/configurations/simple_without_autostart/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>config with nicos 1</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2022-06-14 15:16:16</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,9 +1,9 @@
 setlocal
 call create_virtual_env.bat
-start /wait cmd /c %EPICS_ROOT%\stop_ibex_server.bat
+call %EPICS_ROOT%\stop_ibex_server.bat
 python test_setup_teardown.py>base_line_memory.txt
 set /P BASE_MEMORY_USAGE=<base_line_memory.txt
-start /wait cmd /c %EPICS_ROOT%\start_ibex_server.bat
+call %EPICS_ROOT%\start_ibex_server.bat
 set "PYTHONUNBUFFERED=1"
 set "exitcode=0"
 python "%~dp0run_tests.py" %*
@@ -21,5 +21,5 @@ IF %errorlevel% NEQ 0 (
 
 :finish
 python test_setup_teardown.py --tear_down
-start /wait cmd /c %EPICS_ROOT%\stop_ibex_server.bat
+call %EPICS_ROOT%\stop_ibex_server.bat
 EXIT /b %exitcode%

--- a/test_blockserver.py
+++ b/test_blockserver.py
@@ -6,11 +6,13 @@ from typing import Callable
 from genie_python.utilities import compress_and_hex
 
 from utilities import utilities
+from utilities.utilities import parameterized_list
 import time
 from genie_python import genie as g
 import requests
 from hamcrest import *
 import socket
+from parameterized import parameterized
 
 
 SECONDS_TO_WAIT_FOR_IOC_STARTS = 120
@@ -85,10 +87,12 @@ class TestBlockserver(unittest.TestCase):
         else:
             raise err
 
-    def test_GIVEN_config_changes_by_ioc_and_one_ioc_has_same_settings_in_old_and_new_WHEN_changing_configs_THEN_ioc_not_restarted(self):
-        utilities.load_config_if_not_already_loaded("simple1")
+    @parameterized.expand(parameterized_list([("simple1", "simple2"), 
+                                              ("simple1","block_in_title")]))
+    def test_GIVEN_config_changes_by_ioc_and_one_ioc_has_same_settings_in_old_and_new_WHEN_changing_configs_THEN_ioc_not_restarted(self, _, old_config, new_config):
+        utilities.load_config_if_not_already_loaded(old_config)
 
-        utilities.wait_for_iocs_to_be_up(["SIMPLE", "AG33220A_01"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
+        utilities.wait_for_iocs_to_be_up(["SIMPLE"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
         time.sleep(30)  # Time for IOCs to fully boot etc
 
         simple_start_time_pv = "CS:IOC:SIMPLE:DEVIOS:STARTTOD"
@@ -97,8 +101,8 @@ class TestBlockserver(unittest.TestCase):
         )[simple_start_time_pv]
 
         # Load a config containing a different IOC, but still containing SIMPLE (with the same settings as before)
-        utilities.load_config_if_not_already_loaded("simple2")
-        utilities.wait_for_iocs_to_be_up(["SIMPLE", "AG3631A_01"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
+        utilities.load_config_if_not_already_loaded(new_config)
+        utilities.wait_for_iocs_to_be_up(["SIMPLE"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
         time.sleep(30)  # Time for IOCs to fully boot etc
 
         new_simple_start_time = utilities.wait_for_string_pvs_to_not_be_empty(
@@ -107,6 +111,32 @@ class TestBlockserver(unittest.TestCase):
 
         # Assert that SIMPLE start time has not changed, i.e. SIMPLE didn't restart as a result of the config change.
         self.assertEqual(simple_start_time, new_simple_start_time)
+
+## other test to add
+#    @parameterized.expand(parameterized_list([("simple1", "simple2"), 
+#                                              ("simple1","block_in_title")]))
+#    def test_GIVEN_config_changes_by_ioc_and_ioc_has_different_settings_in_old_and_new_WHEN_changing_configs_THEN_ioc_is_restarted(self, _, old_config, new_config):
+#        utilities.load_config_if_not_already_loaded(old_config)
+#
+#        utilities.wait_for_iocs_to_be_up(["SIMPLE"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
+#        time.sleep(30)  # Time for IOCs to fully boot etc
+#
+#        simple_start_time_pv = "CS:IOC:SIMPLE:DEVIOS:STARTTOD"
+#        simple_start_time = utilities.wait_for_string_pvs_to_not_be_empty(
+#            [simple_start_time_pv], SECONDS_TO_WAIT_FOR_IOC_STARTS, is_local=True
+#        )[simple_start_time_pv]
+#
+#        # Load a config containing a different IOC, but still containing SIMPLE (with the same settings as before)
+#        utilities.load_config_if_not_already_loaded(new_config)
+#        utilities.wait_for_iocs_to_be_up(["SIMPLE"], SECONDS_TO_WAIT_FOR_IOC_STARTS)
+#        time.sleep(30)  # Time for IOCs to fully boot etc
+
+#        new_simple_start_time = utilities.wait_for_string_pvs_to_not_be_empty(
+#            [simple_start_time_pv], SECONDS_TO_WAIT_FOR_IOC_STARTS, is_local=True
+#        )[simple_start_time_pv]
+#
+#        # Assert that SIMPLE start time has changed, i.e. SIMPLE didn't restart as a result of the config change.
+#        self.assertNotEqual(simple_start_time, new_simple_start_time)
 
     def test_GIVEN_config_changes_to_empty_and_back_again_THEN_runcontrol_settings_reset_to_config_defaults(self):
         utilities.load_config_if_not_already_loaded("rcptt_simple")

--- a/test_blockserver.py
+++ b/test_blockserver.py
@@ -144,6 +144,19 @@ class TestBlockserver(unittest.TestCase):
         # Assert that SIMPLE start time has changed, as the IOC has different settings in the new config
         self.assertNotEqual(simple_start_time, new_simple_start_time)
 
+    def test_GIVEN_manually_started_ioc_WHEN_changing_to_config_containing_ioc_but_without_autostart_THEN_ioc_stopped(self):
+        utilities.load_config_if_not_already_loaded("empty_for_system_tests")
+
+        assert_with_timeout(lambda: self.assertEqual(utilities.is_ioc_up("SIMPLE"), False), timeout=30)
+
+        utilities.start_ioc("SIMPLE")
+
+        assert_with_timeout(lambda: self.assertEqual(utilities.is_ioc_up("SIMPLE"), True), timeout=30)
+
+        utilities.load_config_if_not_already_loaded("simple_without_autostart")
+
+        assert_with_timeout(lambda: self.assertEqual(utilities.is_ioc_up("SIMPLE"), False), timeout=30)
+
     def test_GIVEN_config_changes_to_empty_and_back_again_THEN_runcontrol_settings_reset_to_config_defaults(self):
         utilities.load_config_if_not_already_loaded("rcptt_simple")
 

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from genie_python.utilities import dehex_and_decompress, compress_and_hex
 
-WAIT_FOR_SERVER_TIMEOUT = 200
+WAIT_FOR_SERVER_TIMEOUT = 30
 """Number of seconds to wait for a pv to become available in the config server e.g. when it starts or 
 when it changed config"""
 


### PR DESCRIPTION
### Description of work

Add system test asserting that blockserver doesn't restart an IOC that hasn't changed, even if other IOCs in the configuration have changed.

This is necessary so that NICOS, which is now an IOC in a configuration like any other, is not restarted on each config change.

### Ticket

https://github.com/IsisComputingGroup/ibex/issues/7135

### Acceptance criteria

- [ ] Test passes

### Unit tests

n/a

### System tests

This PR

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Running-Nicos

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

