### PR TITLE
Add exception for importing private packages

### DIFF
--- a/test_genie_python_common_imports.py
+++ b/test_genie_python_common_imports.py
@@ -24,7 +24,7 @@ class TestGeniePythonImports(unittest.TestCase):
         :return: None if no error on import, String describing error if there was an error.
         """
 
-        if module_name in IGNORED_MODULES:
+        if module_name in IGNORED_MODULES or module_name.startswith("_"):
             return None
 
         try:


### PR DESCRIPTION
### Description of work

In `test_genie_python_common_imports.py`, added an exception for importing private modules.

### Ticket

Link to ticket: https://github.com/ISISComputingGroup/IBEX/issues/7312

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

