### PR TITLE
Ticket8411_motor_control_genie_cli_tests

### DIFF
--- a/configs/configurations/advanced/blocks.xml
+++ b/configs/configurations/advanced/blocks.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<blocks xmlns="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:blk="http://epics.isis.rl.ac.uk/schema/blocks/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/advanced/components.xml
+++ b/configs/configurations/advanced/components.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<components xmlns="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:comp="http://epics.isis.rl.ac.uk/schema/components/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/advanced/groups.xml
+++ b/configs/configurations/advanced/groups.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<groups xmlns="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:grp="http://epics.isis.rl.ac.uk/schema/groups/1.0" xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/configs/configurations/advanced/iocs.xml
+++ b/configs/configurations/advanced/iocs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<iocs xmlns="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:ioc="http://epics.isis.rl.ac.uk/schema/iocs/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<ioc name="GALIL_01" autostart="true" restart="true" remotePvPrefix="" simlevel="recsim">
+		<macros>
+			<macro name="ENCAVNSAMP" value=""/>
+			<macro name="GALILADDR" value="0.0.0.0"/>
+			<macro name="MTRCTRL" value="1"/>
+		</macros>
+		<pvs/>
+		<pvsets/>
+	</ioc>
+</iocs>

--- a/configs/configurations/advanced/meta.xml
+++ b/configs/configurations/advanced/meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<meta>
+	<description>Testing genie python advanced scripts</description>
+	<synoptic>-- NONE --</synoptic>
+	<edits>
+		<edit>2024-07-08 13:01:05</edit>
+	</edits>
+	<isProtected>false</isProtected>
+	<isDynamic>false</isDynamic>
+	<configuresBlockGWAndArchiver>false</configuresBlockGWAndArchiver>
+</meta>

--- a/test_genie_python_advanced.py
+++ b/test_genie_python_advanced.py
@@ -1,0 +1,68 @@
+import unittest
+
+from utilities.utilities import load_config_if_not_already_loaded, g, \
+    set_genie_python_raises_exceptions
+
+ADV_CONFIG_NAME = "advanced"
+
+
+class TestAdvancedMotorControls(unittest.TestCase):
+    def setUp(self):
+        g.set_instrument(None)
+        load_config_if_not_already_loaded(ADV_CONFIG_NAME)
+        set_genie_python_raises_exceptions(True)
+
+    def test_GIVEN_manager_mode_WHEN_calling_get_manager_mode_THEN_returns_true(self):
+        g.set_pv("CS:MANAGER", "Yes", True, True)  # Check that the get_manager_mode() function works as expected.
+        assert g.adv.get_manager_mode()
+
+        g.set_pv("CS:MANAGER", "No", True, True)
+        assert not g.adv.get_manager_mode()
+
+    def test_GIVEN_no_manager_mode_WHEN_setting_motor_position_THEN_exception_is_raised(self):
+        g.set_pv("CS:MANAGER", "No", True, True)
+
+        with self.assertRaises(RuntimeError):
+            # Check that the user will not be allowed to change the motor position without being in manager mode
+            g.adv.set_motor_position("MTR0101", 1000)
+
+    def test_GIVEN_invalid_motor_name_WHEN_setting_motor_position_THEN_exception_is_raised(self):
+        g.set_pv("CS:MANAGER", "Yes", True, True)
+
+        with self.assertRaises(ValueError):
+            # Check that the set_motor_position will only accept motors it recognises
+            g.adv.set_motor_position("INVALID_MOTOR_NAME", 1000)
+
+    def test_GIVEN_manager_mode_and_valid_motor_name_WHEN_setting_motor_position_THEN_no_exception_raised(self):
+        params = [(1000, "Frozen"), (-1000, "Frozen"), (1000, "Variable"), (-1000, "Variable")]
+        g.set_pv("CS:MANAGER", "Yes", True, True)
+
+        for motor_value, foff_value in params:
+
+            g.set_pv(g.my_pv_prefix + "MOT:MTR0101.FOFF", foff_value, True, True)
+
+            g.adv.set_motor_position("MTR0101", motor_value)
+
+            assert motor_value == g.get_pv(g.my_pv_prefix + "MOT:MTR0101.VAL")
+            # Assert that the motor position changes after calling set_motor_position()
+            assert g.get_pv(g.my_pv_prefix + "MOT:MTR0101.SET", True) == "Use"
+            # Check that MOT:MTR0101.SET is in Use mode after calling set_motor_position()
+            assert g.get_pv(g.my_pv_prefix + "MOT:MTR0101.FOFF") == foff_value
+            # Check that MOT:MTR0101.FFOF is in the same mode before and after calling set_motor_position()
+
+    def test_GIVEN_motor_is_moving_WHEN_setting_motor_position_THEN_exception_raised(self):
+        g.set_pv("CS:MANAGER", "Yes", True, True)
+        g.set_pv(g.my_pv_prefix + "MOT:MTR0101.SET", 0, True)  # Use mode
+
+        g.set_pv(g.my_pv_prefix + "MOT:MTR0101.VAL", 30000.0, False)  # Set position so that motor begins moving
+
+        with self.assertRaises(RuntimeError) as e:
+            print(e)
+            g.adv.set_motor_position("MTR0101", 1000)  # Check that it throws as exception as it is moving
+
+    def tearDown(self):
+        g.set_pv(g.my_pv_prefix + "MOT:MTR0101.STOP", 1, True)  # Make sure motor is not moving
+        g.set_pv(g.my_pv_prefix + "MOT:MTR0101.SET", 1, True)  # Set mode
+        g.set_pv(g.my_pv_prefix + "MOT:MTR0101.VAL", 0.0, True)  # Motor is repositioned
+        g.set_pv("CS:MANAGER", "No", True, True)  # Make sure not in manager mode
+        set_genie_python_raises_exceptions(False)


### PR DESCRIPTION
### Description of work

Added tests and configuration for new support of redefining motor positions from the genie command line. 

### Ticket

[Ticket8411](https://github.com/ISISComputingGroup/IBEX/issues/8411)

### Acceptance criteria

- All tests pass
- Tests are extensive enough

### System tests

- test_GIVEN_manager_mode_WHEN_calling_get_manager_mode_THEN_returns_true - Test that setting when setting the manager mode to a new value, g.adv.get_manager_mode() returns this value.
- test_GIVEN_no_manager_mode_WHEN_setting_motor_position_THEN_exception_is_raised - Test that if the user is not in manager mode they cannot redefine motor position.
- test_GIVEN_invalid_motor_name_WHEN_setting_motor_position_THEN_exception_is_raised - Checks that if the motor name supplied is not valid then an exception is thrown.
- test_GIVEN_foff_is_variable_and_set_is_use_WHEN_setting_motor_position_THEN_foff_and_set_change_before_and_after - Checks that before the motor position is redefined, that SET is on 'Set' and FOFF is on 'Frozen'. Also checks that after redefining the motor position, SET is on 'Use' and FOFF is the same state as it was initially.
- test_GIVEN_manager_mode_and_valid_motor_name_WHEN_setting_motor_position_THEN_motor_position_set - Tests that with valid parameters that there are no exceptions thrown.
- test_GIVEN_motor_is_moving_WHEN_setting_motor_position_THEN_exception_raised - Test that while the motor is moving the user cannot redefine the motor position.
- test_GIVEN_invalid_pv_WHEN_calling_motor_in_set_mode_THEN_exception_raised - Test that the motor_in_set_mode function will not accept an invalid PV.
- test_GIVEN_valid_pv_but_not_a_motor_pv_WHEN_calling_motor_in_set_mode_THEN_exception_raised - Test that the motor_in_set_mode function will not accept a valid PV that does not point to a motor.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

