### PR TITLE
Don't import pip

### DIFF
--- a/test_genie_python_common_imports.py
+++ b/test_genie_python_common_imports.py
@@ -9,6 +9,19 @@ IGNORED_MODULES = {
     "dockerpty",  # Not supported on windows
     "adodbapi",  # Not needed by users
     "black",  # Not needed by users
+    # importing pip overwrites distutils in sys.modules
+    # with a copy of setuptools instead, which then breaks
+    # any packages that depend on distutils directly.
+    # https://github.com/pypa/pip/issues/8761
+    #
+    # Importing pip as a module in general is a bad idea (tm), so just don't do that.
+    #
+    # It's possible to use:
+    # >>> import _distutils_hack
+    # >>> _distutils_hack.remove_shim()
+    # >>> import pip
+    # if someone *really* needs to import pip (yes, seriously; no, it's not a good idea).
+    "pip",
 }
 
 
@@ -17,7 +30,7 @@ class TestGeniePythonImports(unittest.TestCase):
     Tests that modules which users use can be imported.
     """
 
-    def _attempt_to_import_module_by_name(self, module_name):
+    def _attempt_to_import_module_by_name(self, module_name: str) -> str | None:
         """
         Attempts to import a module by name.
         :param module_name: the module name to import
@@ -38,12 +51,13 @@ class TestGeniePythonImports(unittest.TestCase):
         else:
             return None
 
-    def test_WHEN_importing_all_installed_packages_THEN_no_error(self):
+    def test_WHEN_importing_all_installed_packages_THEN_no_error(self) -> None:
         """
         This tests that all of the modules we've installed are importable as modules.
         """
 
-        # Ignore warnings. We get lots of these from various modules and it's too noisy for this test suite.
+        # Ignore warnings. We get lots of these from various modules and it's too noisy for this
+        # test suite.
         warnings.filterwarnings("ignore")
 
         failures = []


### PR DESCRIPTION
fix common_imports system test by not importing `pip` (which is unrecommended anyway; see https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program), it messes about with various global state e.g.:

>  The pip code assumes that it is in sole control of the global state of the program. pip manages things like the logging system configuration, or the values of the standard IO streams, without considering the possibility that user code might be affected.
>
> pip’s code is not thread safe. If you were to run pip in a thread, there is no guarantee that either your code or pip’s would work as you expect.
> 
> pip assumes that once it has finished its work, the process will terminate. It doesn’t need to handle the possibility that other code will continue to run after that point, so (for example) calling pip twice in the same process is likely to have issues.

That last point is likely what we are running into - we're importing a bunch of modules alphabetically, so a load of modules after `pip` alphbetically violate it by continuing to run after an `import pip` has run.


Note: it only failed reliably on build server, not dev machines.