### PR TITLE
Fix race condition on initial value?

### DIFF
--- a/test_genie_python_using_simple.py
+++ b/test_genie_python_using_simple.py
@@ -236,7 +236,9 @@ class TestWaitforBlock(unittest.TestCase):
         self.wait_before = 1
         self.wait_after = 2
         self.max_wait = (self.wait_before + self.wait_after) * 2
-        g.cset(self.block_name, 0)
+        initial_block_value = 0
+        g.cset(self.block_name, initial_block_value)
+        g.waitfor_block(self.block_name, value=initial_block_value , maxwait=TIMEOUT)
         assert_that(check_block_exists(self.block_name), is_(True))
 
     def test_GIVEN_waiting_for_exact_value_on_block_WHEN_block_reaches_value_THEN_waitfor_completes(


### PR DESCRIPTION
### Description of work

Potentially fix error in `test_GIVEN_waiting_for_exact_value_on_block_WHEN_block_wrong_value_THEN_timeout (test_genie_python_using_simple.TestWaitforBlock.test_GIVEN_waiting_for_exact_value_on_block_WHEN_block_wrong_value_THEN_timeout)` - at moment it looks like a race condition on initial block value not gettign reset quickly enough in setup 

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

